### PR TITLE
Add unit tests and feature proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Python virtual environments
+*.venv/
+venv/
+.env
+
+# Python cache
+__pycache__/
+*.pyc
+
+# environment files
+.env

--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -1,0 +1,26 @@
+# Feature Proposal
+
+This repository currently provides a CLI script (`run_screener.py`) that submits a prompt to OpenAI and stores the response. The following improvements could significantly expand its usability and reliability.
+
+## 1. Web-Based Dashboard
+- **Framework**: Use FastAPI for API endpoints and a lightweight front end (e.g., Svelte or React) to display screening results.
+- **Scheduling**: Run the screener at regular intervals via Celery or APScheduler and update a database (SQLite or PostgreSQL).
+- **Authentication**: Simple API key or OAuth support for multiple users.
+- **Visualization**: Integrate chart libraries (Plotly) for momentum, volatility and depth heat maps.
+
+## 2. macOS Desktop App
+- **Toolkit**: Leverage PyObjC or Electron to wrap the web interface as a standalone macOS application.
+- **Notifications**: macOS Notification Center alerts when new trade setups appear.
+- **Local Storage**: Cache recent API responses for offline viewing.
+
+## 3. Reliability Improvements
+- **Dependency Management**: Add a `requirements.txt` with pinned package versions.
+- **Error Handling**: Gracefully report missing API keys or network failures.
+- **Unit Tests**: Expand test coverage to include the CLI workflow and JSON schema validation.
+
+## 4. Additional Analytics
+- **On‑chain metrics**: Incorporate APIs such as Glassnode or Santiment for network statistics.
+- **Social sentiment**: Schedule scrapers for Twitter/X, Reddit, and Telegram using official APIs where possible.
+- **Backtesting module**: Allow users to evaluate historical strategy performance on selected pairs.
+
+These features would transform the script into a comprehensive, user‑friendly platform for advanced crypto screening.

--- a/crypto_screener_ai/app/prompt_template.txt
+++ b/crypto_screener_ai/app/prompt_template.txt
@@ -1,0 +1,28 @@
+# --- SYSTEM MESSAGE ---
+You are **CryptoScreenerAI**, a quant-driven cryptocurrency strategist.
+#  … (same SYSTEM block as before)
+
+# --- USER MESSAGE TEMPLATE ---
+<<TASK PARAMETERS>>
+### Task 1 – Momentum & Volatility Screener
+#  … (unchanged Tasks 1-7)
+### Task 8 – 5 Best Ideas / 30 Minutes
+Fetch the five highest-conviction opportunities over the next 30 minutes
+(momentum, volume-burst or swing-setup).  
+Return for each:
+• symbol • rationale (≤40 w) • trade_type • entry • exit • timeframe_minutes
+• probability_of_success • letter_grade (A–E).
+
+# --- OUTPUT SCHEMA ADDENDUM ---
+"best_ideas_30m": [
+  {
+    "symbol": "string",
+    "trade_type": "momentum|volume|swing",
+    "entry": "float",
+    "exit": "float",
+    "timeframe_minutes": 30,
+    "probability_of_success": "float",
+    "letter_grade": "A|B|C|D|E",
+    "rationale": "string"
+  }
+]

--- a/crypto_screener_ai/app/run_screener.py
+++ b/crypto_screener_ai/app/run_screener.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+"""
+run_screener.py – call OpenAI with your CryptoScreener prompt template
+
+New features:
+  • --symbol or -s lets you analyse any extra coin on-the-fly
+  • Automatically appends top-25-by-volume (CoinGecko) to the watch-list
+  • Adds Task 8 asking for five best ideas in next 30 min
+"""
+import json, os, uuid, datetime, argparse, requests
+from pathlib import Path
+from dotenv import load_dotenv
+from rich import print
+from openai import OpenAI
+
+# ---------- helpers -----------------------------------------------------------
+def fetch_top_25_volume(vs_currency: str = "usd") -> list[str]:
+    url = ("https://api.coingecko.com/api/v3/coins/markets"
+           f"?vs_currency={vs_currency}&order=volume_desc&per_page=25&page=1")
+    try:
+        res = requests.get(url, timeout=10)
+        res.raise_for_status()
+        return [coin["symbol"].upper() for coin in res.json()]
+    except Exception as exc:
+        print(f"[yellow]⚠️  Could not fetch top-25 volume list ({exc}); "
+              "continuing with defaults.[/]")
+        return []
+
+# ---------- main --------------------------------------------------------------
+def main():
+    load_dotenv()
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+    parser = argparse.ArgumentParser(
+        description="Run CryptoScreenerAI prompt through OpenAI Completion")
+    parser.add_argument("-s", "--symbol", help="Extra symbol to analyse (e.g. DOGE)")
+    args = parser.parse_args()
+
+    # base watch-list
+    symbols = ["SOL","ETH","BTC","BNB","XRP","QNT","TON","ETC",
+               "AVAX","ADA","ALGO","LTC"]
+
+    # add top-25 volume
+    symbols += [sym for sym in fetch_top_25_volume() if sym not in symbols]
+
+    # add optional user-requested symbol
+    if args.symbol:
+        symbols.append(args.symbol.upper())
+
+    # compose parameter bundle
+    params = {
+        "run_id": str(uuid.uuid4()),
+        "as_of": datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "symbols": symbols,
+        "leverage": 50,
+        "budget_per_order_min": 5,
+        "budget_per_order_max": 20,
+        "budget_per_coin_max": 50,
+        "watch_windows": ["30m","1h","2h-4h","4h-8h"],
+        "data_sources": {
+            "price": "CoinGecko",
+            "order_book": "Binance",
+            "sentiment": ["Twitter","Reddit","Telegram","GoogleTrends"],
+            "macro": ["DXY","SPX","US10Y"]
+        }
+    }
+
+    template_path = Path(__file__).with_name("prompt_template.txt")
+    template = template_path.read_text()
+
+    user_prompt = template.replace("<<TASK PARAMETERS>>",
+                                   json.dumps(params, indent=2))
+
+    messages = [
+        {"role": "system", "content":
+            template.split("USER MESSAGE TEMPLATE")[0]},
+        {"role": "user", "content": user_prompt},
+        {"role": "assistant", "content": "Return JSON only."}
+    ]
+
+    print("[bold cyan]🚀  Requesting analysis …[/]")
+    response = client.chat.completions.create(
+        model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+        messages=messages,
+        temperature=0.3,
+        max_tokens=2800
+    )
+
+    reply = response.choices[0].message.content
+    Path("last_response.json").write_text(reply)
+    print("\n[green]LLM response saved to last_response.json[/]")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -1,0 +1,78 @@
+import sys
+import types
+import importlib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def load_module_with_mocks():
+    # mock requests module
+    dummy_requests = types.ModuleType('requests')
+    class DummyResponse:
+        def __init__(self, data, raise_exc=False):
+            self._data = data
+            self.raise_exc = raise_exc
+        def json(self):
+            if self.raise_exc:
+                raise ValueError('bad json')
+            return self._data
+        def raise_for_status(self):
+            if self.raise_exc:
+                raise Exception('err')
+    dummy_requests.Response = DummyResponse
+    dummy_requests._next_response = DummyResponse([])
+    def get(url, timeout=10):
+        return dummy_requests._next_response
+    dummy_requests.get = get
+    sys.modules['requests'] = dummy_requests
+
+    # mock dotenv module
+    dummy_dotenv = types.ModuleType('dotenv')
+    def load_dotenv(*args, **kwargs):
+        pass
+    dummy_dotenv.load_dotenv = load_dotenv
+    sys.modules['dotenv'] = dummy_dotenv
+
+    # mock rich.print
+    dummy_rich = types.ModuleType('rich')
+    def dummy_print(*args, **kwargs):
+        builtins.print(*args, **kwargs)
+    import builtins
+    dummy_rich.print = dummy_print
+    sys.modules['rich'] = dummy_rich
+
+    # mock openai module
+    dummy_openai = types.ModuleType('openai')
+    class DummyCompletions:
+        def create(self, **kwargs):
+            class Msg:
+                content = '{}'
+            class Choice:
+                message = Msg()
+            class Resp:
+                choices = [Choice()]
+            return Resp()
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            self.chat = types.SimpleNamespace(completions=DummyCompletions())
+    dummy_openai.OpenAI = DummyClient
+    sys.modules['openai'] = dummy_openai
+
+    return importlib.import_module('crypto_screener_ai.app.run_screener')
+
+
+def test_fetch_top_25_volume_success():
+    mod = load_module_with_mocks()
+    mod.requests._next_response = mod.requests.Response([{'symbol': 'eth'}, {'symbol': 'btc'}])
+    result = mod.fetch_top_25_volume()
+    assert result == ['ETH', 'BTC']
+
+
+def test_fetch_top_25_volume_failure(capsys):
+    mod = load_module_with_mocks()
+    mod.requests._next_response = mod.requests.Response([], raise_exc=True)
+    result = mod.fetch_top_25_volume()
+    captured = capsys.readouterr()
+    assert result == []
+    assert 'Could not fetch top-25 volume list' in captured.out


### PR DESCRIPTION
## Summary
- add prompt template and CLI script for CryptoScreenerAI
- add lightweight unit tests covering `fetch_top_25_volume`
- provide a `PROPOSAL.md` with potential feature enhancements
- ignore venv and cache artifacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1a8bb8b8832baa87d586ecefea6c

## Summary by Sourcery

Add a CLI tool and prompt template for CryptoScreenerAI, introduce basic unit tests for the volume-fetching helper, include a feature proposal document, and update gitignore

New Features:
- Introduce a run_screener CLI script that builds a watch list (including top-25-volume symbols and optional extra symbols), loads a prompt template, and submits analysis requests to OpenAI

Documentation:
- Add PROPOSAL.md outlining potential feature expansions such as a web dashboard, desktop app, reliability improvements, and advanced analytics

Tests:
- Add pytest unit tests for fetch_top_25_volume covering both successful data retrieval and error handling

Chores:
- Add .gitignore to exclude virtual environment and cache artifacts