### PR TITLE
Add web dashboard and autorun script

### DIFF
--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -24,3 +24,8 @@ This repository currently provides a CLI script (`run_screener.py`) that submits
 - **Backtesting module**: Allow users to evaluate historical strategy performance on selected pairs.
 
 These features would transform the script into a comprehensive, user‑friendly platform for advanced crypto screening.
+
+## 5. Complementary Features
+- **Automated Deployment**: Provide a simple `autorun.sh` script that installs dependencies and launches the dashboard on ports 9999 and 9998.
+- **Alerts**: Optional integration with Telegram or Discord webhooks to broadcast new screener results.
+- **Caching & Backtesting**: Store past responses in SQLite to enable quick backtests and offline access.

--- a/README.md
+++ b/README.md
@@ -142,3 +142,6 @@ Output strictly conforms to the schema.
 }
 
 
+
+## Autorun
+Run `./autorun.sh` to install dependencies and launch the dashboard.

--- a/autorun.sh
+++ b/autorun.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+pip install -r requirements.txt
+python -m crypto_screener_ai.web.run_dashboard

--- a/crypto_screener_ai/web/dashboard.py
+++ b/crypto_screener_ai/web/dashboard.py
@@ -1,0 +1,81 @@
+import json
+import os
+import sqlite3
+from pathlib import Path
+from fastapi import FastAPI, Depends, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.security.api_key import APIKeyHeader
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from ..app import run_screener
+
+DB_PATH = Path(__file__).resolve().parents[1] / 'data'
+DB_PATH.mkdir(exist_ok=True)
+DB_FILE = DB_PATH / 'screener.db'
+
+API_KEY = os.getenv('API_KEY', 'demo')
+api_key_header = APIKeyHeader(name='X-API-Key')
+
+app = FastAPI(title='CryptoScreenerAI Dashboard')
+
+
+def get_db():
+    conn = sqlite3.connect(DB_FILE)
+    conn.execute('''CREATE TABLE IF NOT EXISTS results (
+                        run_id TEXT PRIMARY KEY,
+                        ts TEXT,
+                        data TEXT
+                    )''')
+    return conn
+
+
+def require_key(key: str = Depends(api_key_header)):
+    if key != API_KEY:
+        raise HTTPException(status_code=401, detail='Invalid API key')
+
+
+@app.get('/', response_class=HTMLResponse)
+async def index():
+    html = (Path(__file__).with_name('frontend') / 'index.html').read_text()
+    return HTMLResponse(html)
+
+
+@app.get('/results/latest')
+async def latest(key: str = Depends(require_key)):
+    conn = get_db()
+    cur = conn.execute('SELECT data FROM results ORDER BY ts DESC LIMIT 1')
+    row = cur.fetchone()
+    conn.close()
+    if not row:
+        return {}
+    return json.loads(row[0])
+
+
+@app.get('/results/{run_id}')
+async def get_result(run_id: str, key: str = Depends(require_key)):
+    conn = get_db()
+    cur = conn.execute('SELECT data FROM results WHERE run_id = ?', (run_id,))
+    row = cur.fetchone()
+    conn.close()
+    if not row:
+        raise HTTPException(status_code=404, detail='Not found')
+    return json.loads(row[0])
+
+
+def screener_job():
+    run_screener.main()
+    path = Path('last_response.json')
+    if path.exists():
+        data = path.read_text()
+        js = json.loads(data)
+        conn = get_db()
+        conn.execute('INSERT OR REPLACE INTO results(run_id, ts, data) VALUES(?, ?, ?)',
+                     (js.get('run_id'), js.get('as_of'), data))
+        conn.commit()
+        conn.close()
+
+
+scheduler = BackgroundScheduler()
+scheduler.add_job(screener_job, 'interval', hours=1)
+scheduler.start()
+

--- a/crypto_screener_ai/web/frontend/index.html
+++ b/crypto_screener_ai/web/frontend/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>CryptoScreenerAI Dashboard</title>
+  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+</head>
+<body>
+  <h1>CryptoScreenerAI Dashboard</h1>
+  <div id="content"></div>
+  <script>
+    async function loadLatest() {
+      const resp = await fetch('/results/latest', {headers:{'X-API-Key': 'demo'}});
+      const data = await resp.json();
+      const pre = document.createElement('pre');
+      pre.textContent = JSON.stringify(data, null, 2);
+      document.getElementById('content').appendChild(pre);
+    }
+    loadLatest();
+  </script>
+</body>
+</html>

--- a/crypto_screener_ai/web/run_dashboard.py
+++ b/crypto_screener_ai/web/run_dashboard.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from . import dashboard
+
+
+def main():
+    # run uvicorn on port 9999
+    backend = subprocess.Popen([sys.executable, '-m', 'uvicorn', 'crypto_screener_ai.web.dashboard:app', '--port', '9999'])
+    # serve static frontend via simple http server on port 9998
+    front_dir = Path(__file__).with_name('frontend')
+    frontend = subprocess.Popen([sys.executable, '-m', 'http.server', '9998', '--directory', str(front_dir)])
+    try:
+        backend.wait()
+    finally:
+        frontend.terminate()
+        backend.terminate()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+APScheduler==3.10.4
+python-dotenv
+requests
+openai
+plotly
+rich


### PR DESCRIPTION
## Summary
- introduce FastAPI dashboard with APScheduler-backed screener job
- store screener results in SQLite and serve them via API
- simple Plotly-capable frontend
- autorun script installs requirements and starts API on port 9999 with static frontend on port 9998
- document new capabilities and proposal updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1dc10d98832b93ce7d65987bdea5

## Summary by Sourcery

Introduce a FastAPI‐based web dashboard with scheduled screener runs, a Plotly frontend, and an autorun startup script

New Features:
- Add FastAPI dashboard with authenticated endpoints to serve latest and historical screener results
- Embed APScheduler job to run the screener hourly and store JSON results in SQLite
- Provide a simple Plotly‐capable static frontend served via HTTP
- Include a run_dashboard script to launch the backend on port 9999 and frontend on port 9998
- Add an autorun.sh script to install dependencies and start the dashboard automatically

Build:
- Add FastAPI, Uvicorn, APScheduler, Plotly, and related dependencies to requirements.txt

Documentation:
- Document the autorun script in README and update PROPOSAL with deployment and caching features