### PR TITLE
Add macOS client and API resilience features

### DIFF
--- a/PROPOSAL_ADDON.md
+++ b/PROPOSAL_ADDON.md
@@ -1,0 +1,11 @@
+# Additional Feature Proposal
+
+To further extend CryptoScreenerAI, consider implementing the following options:
+
+1. **Real‑Time WebSockets** – stream updates from major exchanges directly to the dashboard and macOS app for instantaneous alerts.
+2. **Advanced Backtesting** – integrate a historical data module allowing users to simulate strategies over past market conditions.
+3. **Portfolio Tracking** – let users enter holdings and track PnL alongside screener recommendations.
+4. **iCloud Sync** – keep user settings and watch lists consistent across macOS devices.
+5. **Auto‑Update Mechanism** – check for new releases of the companion app and prompt users to update.
+
+These enhancements would complement the existing tooling by improving usability, analytics, and cross‑device functionality.

--- a/crypto_screener_ai/app/run_screener.py
+++ b/crypto_screener_ai/app/run_screener.py
@@ -7,24 +7,41 @@ New features:
   • Automatically appends top-25-by-volume (CoinGecko) to the watch-list
   • Adds Task 8 asking for five best ideas in next 30 min
 """
-import json, os, uuid, datetime, argparse, requests
+import json, os, uuid, datetime, argparse, requests, time
+
 from pathlib import Path
 from dotenv import load_dotenv
 from rich import print
 from openai import OpenAI
 
+
 # ---------- helpers -----------------------------------------------------------
-def fetch_top_25_volume(vs_currency: str = "usd") -> list[str]:
-    url = ("https://api.coingecko.com/api/v3/coins/markets"
-           f"?vs_currency={vs_currency}&order=volume_desc&per_page=25&page=1")
-    try:
-        res = requests.get(url, timeout=10)
-        res.raise_for_status()
-        return [coin["symbol"].upper() for coin in res.json()]
-    except Exception as exc:
-        print(f"[yellow]⚠️  Could not fetch top-25 volume list ({exc}); "
-              "continuing with defaults.[/]")
-        return []
+def validate_schema(data: dict, schema_path: Path) -> None:
+    schema = json.loads(schema_path.read_text())
+    for key in schema.get("required", []):
+        if key not in data:
+            raise ValueError(f"missing required key: {key}")
+
+def fetch_top_25_volume(vs_currency: str = "usd", retries: int = 3) -> list[str]:
+    """Fetch top 25 coins by volume with exponential backoff."""
+    url = (
+        "https://api.coingecko.com/api/v3/coins/markets"
+        f"?vs_currency={vs_currency}&order=volume_desc&per_page=25&page=1"
+    )
+    delay = 1
+    for attempt in range(retries):
+        try:
+            res = requests.get(url, timeout=10)
+            res.raise_for_status()
+            return [coin["symbol"].upper() for coin in res.json()]
+        except Exception as exc:
+            if attempt == retries - 1:
+                print(
+                    f"[yellow]⚠️  Could not fetch top-25 volume list ({exc}); continuing with defaults.[/]")
+            else:
+                time.sleep(delay)
+                delay *= 2
+    return []
 
 # ---------- main --------------------------------------------------------------
 def main():
@@ -87,7 +104,14 @@ def main():
     )
 
     reply = response.choices[0].message.content
-    Path("last_response.json").write_text(reply)
+    schema_path = Path(__file__).with_name("schema.json")
+    try:
+        data = json.loads(reply)
+        validate_schema(data, schema_path)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"[red]Invalid LLM payload: {exc}. Response discarded.[/]")
+        return
+    Path("last_response.json").write_text(json.dumps(data, indent=2))
     print("\n[green]LLM response saved to last_response.json[/]")
 
 if __name__ == "__main__":

--- a/crypto_screener_ai/app/schema.json
+++ b/crypto_screener_ai/app/schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "run_id": {"type": "string"},
+    "generated_at": {"type": "string"},
+    "screener": {"type": "object"},
+    "market_overview": {"type": "object"}
+  },
+  "required": ["run_id", "generated_at", "screener"]
+}

--- a/crypto_screener_ai/web/dashboard.py
+++ b/crypto_screener_ai/web/dashboard.py
@@ -8,9 +8,11 @@ from email.message import EmailMessage
 import requests
 from pathlib import Path
 from fastapi import FastAPI, Depends, HTTPException
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.security.api_key import APIKeyHeader
 from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+import csv
 
 from ..app import run_screener
 
@@ -115,6 +117,22 @@ async def get_result(run_id: str, key: str = Depends(require_key)):
     return json.loads(row[0])
 
 
+@app.get('/results/export')
+async def export_results(format: str = 'json', key: str = Depends(require_key)):
+    """Export all stored results as JSON or CSV."""
+    conn = get_db()
+    cur = conn.execute('SELECT run_id, ts, data FROM results ORDER BY ts')
+    rows = cur.fetchall()
+    conn.close()
+    if format == 'csv':
+        def generate():
+            yield 'run_id,ts,data\n'
+            for r in rows:
+                yield f"{r[0]},{r[1]}," + json.dumps(json.loads(r[2])) + "\n"
+        return StreamingResponse(generate(), media_type='text/csv')
+    return [json.loads(r[2]) for r in rows]
+
+
 @app.get('/sentiment')
 async def sentiment():
     """Return the most recently fetched sentiment data."""
@@ -126,6 +144,18 @@ async def predict(symbol: str):
     """Dummy short-term price prediction."""
     change = random.uniform(-0.05, 0.05)
     return {'symbol': symbol.upper(), 'predicted_change': change}
+
+
+@app.get('/health')
+async def health():
+    """Return timestamp and run ID of the most recent screener run."""
+    conn = get_db()
+    cur = conn.execute('SELECT run_id, ts FROM results ORDER BY ts DESC LIMIT 1')
+    row = cur.fetchone()
+    conn.close()
+    if not row:
+        return {'run_id': None, 'ts': None}
+    return {'run_id': row[0], 'ts': row[1]}
 
 
 def screener_job():
@@ -149,7 +179,9 @@ def fetch_sentiment():
     logger.info('Fetched sentiment: %s', SENTIMENT_DATA)
 
 
-scheduler = BackgroundScheduler()
+scheduler = BackgroundScheduler(
+    jobstores={'default': SQLAlchemyJobStore(url=f'sqlite:///{DB_PATH / "jobs.db"}')}
+)
 scheduler.add_job(screener_job, 'interval', hours=1)
 scheduler.add_job(fetch_sentiment, 'interval', minutes=10)
 scheduler.start()

--- a/macos_companion/Package.swift
+++ b/macos_companion/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "CryptoScreenerApp",
+    platforms: [.macOS(.v13)],
+    products: [
+        .executable(name: "CryptoScreenerApp", targets: ["CryptoScreenerApp"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.6.4"),
+        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2"),
+        .package(url: "https://github.com/apple/swift-charts.git", from: "1.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "CryptoScreenerApp",
+            dependencies: ["Alamofire", "KeychainAccess", .product(name: "Charts", package: "swift-charts")],
+            path: "Sources/CryptoScreenerApp"
+        )
+    ]
+)

--- a/macos_companion/Sources/CryptoScreenerApp/main.swift
+++ b/macos_companion/Sources/CryptoScreenerApp/main.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import Alamofire
+import KeychainAccess
+import Charts
+
+@main
+struct CryptoScreenerApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    var body: some Scene {
+        MenuBarExtra("CryptoScreener") {
+            ContentView()
+        }
+    }
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Setup code if needed
+    }
+}
+
+struct PriceInfo: Identifiable {
+    let id = UUID()
+    let symbol: String
+    let price: Double
+    let change: Double
+}
+
+struct ContentView: View {
+    @State private var prices: [PriceInfo] = []
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Dashboard").font(.title)
+            List(prices) { info in
+                HStack {
+                    Text(info.symbol)
+                    Spacer()
+                    Text(String(format: "$%.2f", info.price))
+                        .foregroundColor(info.change >= 0 ? .green : .red)
+                }
+            }
+            .frame(width: 200, height: 150)
+        }
+        .onAppear(perform: fetchPrices)
+        .padding()
+    }
+
+    func fetchPrices() {
+        AF.request("https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum,solana&vs_currencies=usd&include_24hr_change=true")
+            .responseDecodable(of: [String: [String: Double]].self) { response in
+                if case let .success(data) = response.result {
+                    prices = [
+                        PriceInfo(symbol: "BTC", price: data["bitcoin"]?["usd"] ?? 0, change: data["bitcoin"]?["usd_24h_change"] ?? 0),
+                        PriceInfo(symbol: "ETH", price: data["ethereum"]?["usd"] ?? 0, change: data["ethereum"]?["usd_24h_change"] ?? 0),
+                        PriceInfo(symbol: "SOL", price: data["solana"]?["usd"] ?? 0, change: data["solana"]?["usd_24h_change"] ?? 0)
+                    ]
+                }
+            }
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ openai
 plotly
 rich
 scikit-learn
+sqlalchemy


### PR DESCRIPTION
## Summary
- add minimal macOS companion app using Swift Package Manager
- store OpenAI responses only when they pass schema validation
- retry CoinGecko volume fetches with exponential backoff
- persist scheduler jobs using SQLite and expose `/health` and export endpoints
- document additional feature ideas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e355983b0832ba129850a7364b97b

## Summary by Sourcery

Add a minimal macOS companion app, improve API resilience with schema validation and retry logic, persist scheduler jobs, and expose new health and export endpoints

New Features:
- Introduce a macOS companion app built with Swift Package Manager and SwiftUI
- Add `/results/export` endpoint to export stored screener results as JSON or CSV
- Add `/health` endpoint to report the most recent run ID and timestamp
- Persist scheduler jobs in SQLite using SQLAlchemyJobStore

Enhancements:
- Validate OpenAI responses against a JSON schema before saving and discard invalid payloads
- Implement exponential backoff for CoinGecko volume fetches to improve API resilience

Build:
- Add `sqlalchemy` to Python dependencies
- Introduce `Package.swift` for the macOS app with Alamofire, KeychainAccess, and Charts dependencies

Documentation:
- Add `PROPOSAL_ADDON.md` with additional feature proposals for future enhancements