### PR TITLE
Add real-time streaming and portfolio features

### DIFF
--- a/PROPOSAL_FUTURE.md
+++ b/PROPOSAL_FUTURE.md
@@ -1,0 +1,7 @@
+# Future Enhancements
+
+1. **Mobile Companion App** - Develop an iOS version of the macOS companion to receive push notifications and manage watch lists on the go.
+2. **Strategy Marketplace** - Allow users to share and import custom backtesting strategies through a curated marketplace.
+3. **Hardware Wallet Integration** - Connect to Ledger or Trezor devices to display real-time balances within the dashboard.
+4. **Advanced Risk Metrics** - Include Sharpe ratio and drawdown analytics for portfolio tracking.
+5. **Machine Learning Signals** - Experiment with lightweight ML models to surface emerging trading opportunities.

--- a/README.md
+++ b/README.md
@@ -154,3 +154,10 @@ results are stored:
 
 - `PUSHOVER_TOKEN` and `PUSHOVER_USER` for [Pushover](https://pushover.net) messages
 - `SMTP_SERVER`, `SMTP_USER`, `SMTP_PASS`, and `ALERT_EMAIL` for email alerts
+
+## New Features
+- **Real-Time WebSockets**: Subscribe to `/ws/results` for instant screener updates.
+- **Advanced Backtesting**: `/backtest/{symbol}` endpoint simulates strategies using historical prices.
+- **Portfolio Tracking**: Manage holdings via `/portfolio` and view PnL at `/portfolio/pnl`.
+- **iCloud Sync**: The macOS companion stores your watchlist in iCloud for seamless access.
+- **Auto-Update**: The companion app checks a remote JSON file and prompts when a newer version is available.

--- a/crypto_screener_ai/app/backtest.py
+++ b/crypto_screener_ai/app/backtest.py
@@ -1,0 +1,48 @@
+import datetime
+import requests
+from typing import List, Dict
+
+
+def fetch_historical_prices(symbol: str, days: int = 90) -> List[float]:
+    """Fetch daily closing prices from CoinGecko."""
+    url = (
+        f"https://api.coingecko.com/api/v3/coins/{symbol.lower()}/market_chart"
+        f"?vs_currency=usd&days={days}&interval=daily"
+    )
+    res = requests.get(url, timeout=10)
+    res.raise_for_status()
+    data = res.json().get("prices", [])
+    return [p[1] for p in data]
+
+
+def simple_moving_average_cross(prices: List[float], short: int = 5, long: int = 20) -> Dict[str, float]:
+    """Very basic moving average cross backtest."""
+    if long >= len(prices):
+        return {"trades": 0, "return_pct": 0.0}
+    position = False
+    entry_price = 0.0
+    balance = 1.0
+    for i in range(long, len(prices)):
+        short_ma = sum(prices[i-short:i]) / short
+        long_ma = sum(prices[i-long:i]) / long
+        price = prices[i]
+        if not position and short_ma > long_ma:
+            position = True
+            entry_price = price
+        elif position and short_ma < long_ma:
+            position = False
+            balance *= price / entry_price
+    if position:
+        balance *= prices[-1] / entry_price
+    return {"trades": 1 if balance != 1.0 else 0, "return_pct": round((balance-1)*100, 2)}
+
+
+def run_backtest(symbol: str, days: int = 90) -> Dict[str, float]:
+    prices = fetch_historical_prices(symbol, days)
+    if not prices:
+        raise ValueError("No data returned")
+    result = simple_moving_average_cross(prices)
+    result["symbol"] = symbol.upper()
+    result["period_days"] = days
+    result["generated_at"] = datetime.datetime.utcnow().isoformat() + "Z"
+    return result

--- a/crypto_screener_ai/web/dashboard.py
+++ b/crypto_screener_ai/web/dashboard.py
@@ -4,17 +4,18 @@ import random
 import sqlite3
 import logging
 import smtplib
+import asyncio
 from email.message import EmailMessage
 import requests
 from pathlib import Path
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.security.api_key import APIKeyHeader
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 import csv
 
-from ..app import run_screener
+from ..app import run_screener, backtest
 
 DB_PATH = Path(__file__).resolve().parents[1] / 'data'
 DB_PATH.mkdir(exist_ok=True)
@@ -29,6 +30,16 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title='CryptoScreenerAI Dashboard')
 
 SENTIMENT_DATA = {'sentiment': 'neutral', 'score': 0.0}
+
+# websocket state
+connections: set[WebSocket] = set()
+event_loop = None
+
+
+@app.on_event("startup")
+async def capture_loop():
+    global event_loop
+    event_loop = asyncio.get_running_loop()
 
 
 def send_push(message: str):
@@ -80,6 +91,11 @@ def get_db():
                         run_id TEXT PRIMARY KEY,
                         ts TEXT,
                         data TEXT
+                    )''')
+    conn.execute('''CREATE TABLE IF NOT EXISTS portfolio (
+                        symbol TEXT PRIMARY KEY,
+                        quantity REAL,
+                        entry_price REAL
                     )''')
     return conn
 
@@ -133,6 +149,32 @@ async def export_results(format: str = 'json', key: str = Depends(require_key)):
     return [json.loads(r[2]) for r in rows]
 
 
+@app.websocket('/ws/results')
+async def ws_results(websocket: WebSocket):
+    await websocket.accept()
+    connections.add(websocket)
+    conn = get_db()
+    cur = conn.execute('SELECT data FROM results ORDER BY ts DESC LIMIT 1')
+    row = cur.fetchone()
+    conn.close()
+    if row:
+        await websocket.send_text(row[0])
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        connections.discard(websocket)
+
+
+async def broadcast_update(data: str):
+    """Send JSON string to all connected WebSocket clients."""
+    for ws in list(connections):
+        try:
+            await ws.send_text(data)
+        except Exception:
+            connections.discard(ws)
+
+
 @app.get('/sentiment')
 async def sentiment():
     """Return the most recently fetched sentiment data."""
@@ -144,6 +186,70 @@ async def predict(symbol: str):
     """Dummy short-term price prediction."""
     change = random.uniform(-0.05, 0.05)
     return {'symbol': symbol.upper(), 'predicted_change': change}
+
+
+@app.get('/portfolio')
+async def get_portfolio(key: str = Depends(require_key)):
+    conn = get_db()
+    cur = conn.execute('SELECT symbol, quantity, entry_price FROM portfolio')
+    rows = cur.fetchall()
+    conn.close()
+    return [{'symbol': r[0], 'quantity': r[1], 'entry_price': r[2]} for r in rows]
+
+
+@app.post('/portfolio')
+async def upsert_portfolio(item: dict, key: str = Depends(require_key)):
+    symbol = item.get('symbol', '').upper()
+    qty = float(item.get('quantity', 0))
+    entry = float(item.get('entry_price', 0))
+    if not symbol:
+        raise HTTPException(status_code=400, detail='symbol required')
+    conn = get_db()
+    conn.execute('INSERT OR REPLACE INTO portfolio(symbol, quantity, entry_price)'
+                 ' VALUES(?,?,?)', (symbol, qty, entry))
+    conn.commit()
+    conn.close()
+    return {'status': 'ok'}
+
+
+@app.delete('/portfolio/{symbol}')
+async def delete_portfolio(symbol: str, key: str = Depends(require_key)):
+    conn = get_db()
+    conn.execute('DELETE FROM portfolio WHERE symbol = ?', (symbol.upper(),))
+    conn.commit()
+    conn.close()
+    return {'status': 'ok'}
+
+
+@app.get('/portfolio/pnl')
+async def portfolio_pnl(key: str = Depends(require_key)):
+    conn = get_db()
+    cur = conn.execute('SELECT symbol, quantity, entry_price FROM portfolio')
+    rows = cur.fetchall()
+    conn.close()
+    holdings = [{'symbol': r[0], 'quantity': r[1], 'entry_price': r[2]} for r in rows]
+    symbols = ','.join({h['symbol'].lower() for h in holdings})
+    if not symbols:
+        return []
+    url = f'https://api.coingecko.com/api/v3/simple/price?ids={symbols}&vs_currencies=usd'
+    res = requests.get(url, timeout=10)
+    res.raise_for_status()
+    prices = res.json()
+    results = []
+    for h in holdings:
+        current = prices.get(h['symbol'].lower(), {}).get('usd', 0)
+        pnl = (current - h['entry_price']) * h['quantity']
+        results.append({**h, 'current_price': current, 'pnl': pnl})
+    return results
+
+
+@app.get('/backtest/{symbol}')
+async def run_backtest_api(symbol: str, days: int = 90, key: str = Depends(require_key)):
+    try:
+        result = backtest.run_backtest(symbol, days)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return result
 
 
 @app.get('/health')
@@ -171,6 +277,8 @@ def screener_job():
         conn.commit()
         conn.close()
         notify(f"New screener results stored: {js.get('run_id')}")
+        if event_loop:
+            asyncio.run_coroutine_threadsafe(broadcast_update(data), event_loop)
 
 def fetch_sentiment():
     """Update global sentiment data (placeholder implementation)."""

--- a/macos_companion/Sources/CryptoScreenerApp/main.swift
+++ b/macos_companion/Sources/CryptoScreenerApp/main.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Alamofire
 import KeychainAccess
 import Charts
+import Combine
 
 @main
 struct CryptoScreenerApp: App {
@@ -14,8 +15,28 @@ struct CryptoScreenerApp: App {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate {
+    let currentVersion = "1.0.0"
+    var cancellables = Set<AnyCancellable>()
+
     func applicationDidFinishLaunching(_ notification: Notification) {
-        // Setup code if needed
+        checkForUpdate()
+    }
+
+    func checkForUpdate() {
+        guard let url = URL(string: "https://example.com/crypto/version.json") else { return }
+        URLSession.shared.dataTaskPublisher(for: url)
+            .map { $0.data }
+            .decode(type: [String: String].self, decoder: JSONDecoder())
+            .replaceError(with: [:])
+            .receive(on: RunLoop.main)
+            .sink { info in
+                if let latest = info["latest"], latest > currentVersion {
+                    let alert = NSAlert()
+                    alert.messageText = "Update Available"
+                    alert.informativeText = "A newer version (\(latest)) is available."
+                    alert.runModal()
+                }
+            }.store(in: &cancellables)
     }
 }
 
@@ -26,8 +47,34 @@ struct PriceInfo: Identifiable {
     let change: Double
 }
 
+class WebSocketManager: ObservableObject {
+    @Published var latestData: String = ""
+    private var task: URLSessionWebSocketTask?
+
+    func connect() {
+        guard let url = URL(string: "ws://localhost:9999/ws/results") else { return }
+        task = URLSession.shared.webSocketTask(with: url)
+        task?.receive(completionHandler: handle)
+        task?.resume()
+    }
+
+    private func handle(result: Result<URLSessionWebSocketTask.Message, Error>) {
+        switch result {
+        case .success(let msg):
+            if case let .string(text) = msg {
+                DispatchQueue.main.async { [weak self] in self?.latestData = text }
+            }
+            task?.receive(completionHandler: handle)
+        case .failure:
+            break
+        }
+    }
+}
+
 struct ContentView: View {
     @State private var prices: [PriceInfo] = []
+    @State private var watchlist: [String] = NSUbiquitousKeyValueStore.default.array(forKey: "watchlist") as? [String] ?? ["BTC","ETH","SOL"]
+    @StateObject private var ws = WebSocketManager()
     var body: some View {
         VStack(alignment: .leading) {
             Text("Dashboard").font(.title)
@@ -41,19 +88,44 @@ struct ContentView: View {
             }
             .frame(width: 200, height: 150)
         }
-        .onAppear(perform: fetchPrices)
+        .onAppear {
+            fetchPrices()
+            ws.connect()
+            NotificationCenter.default.addObserver(forName: NSUbiquitousKeyValueStore.didChangeExternallyNotification, object: nil, queue: .main) { _ in
+                watchlist = NSUbiquitousKeyValueStore.default.array(forKey: "watchlist") as? [String] ?? watchlist
+            }
+            NSUbiquitousKeyValueStore.default.set(watchlist, forKey: "watchlist")
+            NSUbiquitousKeyValueStore.default.synchronize()
+        }
+        .onReceive(ws.$latestData) { text in
+            guard let data = text.data(using: .utf8),
+                  let js = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let sc = js["screener"] as? [String: Any] else { return }
+            // simple extract of first symbol price
+            if let first = sc.first {
+                let sym = first.key
+                if let info = first.value as? [String: Any],
+                   let window = info.values.first as? [String: Any],
+                   let price = window["entry_price"] as? Double {
+                    prices.insert(PriceInfo(symbol: sym, price: price, change: 0), at: 0)
+                }
+            }
+        }
         .padding()
     }
 
     func fetchPrices() {
-        AF.request("https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum,solana&vs_currencies=usd&include_24hr_change=true")
+        let ids = watchlist.map { $0.lowercased() }.joined(separator: ",")
+        let url = "https://api.coingecko.com/api/v3/simple/price?ids=\(ids)&vs_currencies=usd&include_24hr_change=true"
+        AF.request(url)
             .responseDecodable(of: [String: [String: Double]].self) { response in
                 if case let .success(data) = response.result {
-                    prices = [
-                        PriceInfo(symbol: "BTC", price: data["bitcoin"]?["usd"] ?? 0, change: data["bitcoin"]?["usd_24h_change"] ?? 0),
-                        PriceInfo(symbol: "ETH", price: data["ethereum"]?["usd"] ?? 0, change: data["ethereum"]?["usd_24h_change"] ?? 0),
-                        PriceInfo(symbol: "SOL", price: data["solana"]?["usd"] ?? 0, change: data["solana"]?["usd_24h_change"] ?? 0)
-                    ]
+                    prices = watchlist.map { sym in
+                        let lower = sym.lowercased()
+                        let p = data[lower]?["usd"] ?? 0
+                        let ch = data[lower]?["usd_24h_change"] ?? 0
+                        return PriceInfo(symbol: sym, price: p, change: ch)
+                    }
                 }
             }
     }


### PR DESCRIPTION
## Summary
- implement WebSocket streaming for screener results
- add historical backtesting module and API endpoint
- provide portfolio tracking APIs and DB table
- integrate iCloud sync and auto-update in macOS app
- document new features and future roadmap

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e38672774832ba833f8c78fdbb471

## Summary by Sourcery

Add real-time streaming, historical backtesting, and portfolio tracking features to the API and enhance the macOS companion with live updates, iCloud sync, and auto–update prompts.

New Features:
- Expose a WebSocket endpoint at `/ws/results` for real-time screener updates.
- Provide a backtesting module and `/backtest/{symbol}` endpoint for SMA-based historical simulations.
- Offer portfolio management APIs (`/portfolio`, `/portfolio/{symbol}`) and a `/portfolio/pnl` endpoint with a new DB table.
- Enable the macOS app to stream live screener data via WebSockets and synchronize the watchlist through iCloud.
- Implement an auto-update check in the macOS companion that notifies users of newer versions.

Enhancements:
- Broadcast new screener results to all connected WebSocket clients after each background run.
- Fetch prices dynamically in the macOS app using the user’s iCloud-synced watchlist.

Documentation:
- Update README with new realtime streaming, backtesting, portfolio, iCloud sync, and auto-update features.
- Add `PROPOSAL_FUTURE.md` outlining mobile companion, marketplace, wallet integration, risk metrics, and ML signals roadmap.