### PR TITLE
Add risk metrics and strategy marketplace

### DIFF
--- a/PROPOSAL_COMPLEMENT.md
+++ b/PROPOSAL_COMPLEMENT.md
@@ -1,0 +1,9 @@
+# Complementary Feature Ideas
+
+Building upon the existing roadmap, the following additions could further strengthen CryptoScreenerAI:
+
+1. **Multi-Exchange Aggregator** – support data from Kraken, KuCoin and Bitstamp to widen coverage.
+2. **Automated Trade Execution** – optional module to place orders via exchange APIs when signals trigger.
+3. **Natural Language Assistant** – chat-based helper for querying portfolio stats or strategy results.
+4. **Customisable Dashboards** – drag-and-drop widgets to tailor the web interface to user preferences.
+5. **Cross-Platform Alerts** – send notifications through Slack or Discord alongside email and Pushover.

--- a/README.md
+++ b/README.md
@@ -159,5 +159,7 @@ results are stored:
 - **Real-Time WebSockets**: Subscribe to `/ws/results` for instant screener updates.
 - **Advanced Backtesting**: `/backtest/{symbol}` endpoint simulates strategies using historical prices.
 - **Portfolio Tracking**: Manage holdings via `/portfolio` and view PnL at `/portfolio/pnl`.
+- **Portfolio Risk Metrics**: `/portfolio/risk` returns Sharpe ratio and max drawdown for your holdings.
 - **iCloud Sync**: The macOS companion stores your watchlist in iCloud for seamless access.
 - **Auto-Update**: The companion app checks a remote JSON file and prompts when a newer version is available.
+- **Strategy Marketplace**: Browse sample strategies via `/strategies` and view details at `/strategies/{name}`.

--- a/crypto_screener_ai/app/risk_metrics.py
+++ b/crypto_screener_ai/app/risk_metrics.py
@@ -1,0 +1,57 @@
+import math
+from typing import List, Dict
+
+from .backtest import fetch_historical_prices
+
+
+def portfolio_history(holdings: List[Dict[str, float]], days: int = 90) -> List[float]:
+    """Return portfolio value series for given holdings."""
+    totals: List[float] | None = None
+    for h in holdings:
+        prices = fetch_historical_prices(h['symbol'], days)
+        if len(prices) < days:
+            continue
+        series = [p * h['quantity'] for p in prices]
+        if totals is None:
+            totals = series
+        else:
+            totals = [x + y for x, y in zip(totals, series)]
+    return totals or []
+
+
+def sharpe_ratio(prices: List[float]) -> float:
+    """Compute annualised Sharpe ratio of daily prices."""
+    if len(prices) < 2:
+        return 0.0
+    returns = [(p2 - p1) / p1 for p1, p2 in zip(prices[:-1], prices[1:])]
+    mean = sum(returns) / len(returns)
+    variance = sum((r - mean) ** 2 for r in returns) / len(returns)
+    std = math.sqrt(variance)
+    if std == 0:
+        return 0.0
+    return (mean / std) * math.sqrt(365)
+
+
+def max_drawdown(prices: List[float]) -> float:
+    """Return maximum drawdown percentage for a price series."""
+    if not prices:
+        return 0.0
+    peak = prices[0]
+    max_dd = 0.0
+    for p in prices:
+        if p > peak:
+            peak = p
+        drawdown = (peak - p) / peak
+        if drawdown > max_dd:
+            max_dd = drawdown
+    return max_dd
+
+
+def compute_portfolio_risk(holdings: List[Dict[str, float]], days: int = 90) -> Dict[str, float]:
+    prices = portfolio_history(holdings, days)
+    if not prices:
+        return {"sharpe_ratio": 0.0, "max_drawdown": 0.0}
+    return {
+        "sharpe_ratio": round(sharpe_ratio(prices), 4),
+        "max_drawdown": round(max_drawdown(prices), 4)
+    }

--- a/crypto_screener_ai/web/dashboard.py
+++ b/crypto_screener_ai/web/dashboard.py
@@ -243,6 +243,44 @@ async def portfolio_pnl(key: str = Depends(require_key)):
     return results
 
 
+@app.get('/portfolio/risk')
+async def portfolio_risk(key: str = Depends(require_key), days: int = 90):
+    """Return portfolio-level Sharpe ratio and max drawdown."""
+    conn = get_db()
+    cur = conn.execute('SELECT symbol, quantity FROM portfolio')
+    rows = cur.fetchall()
+    conn.close()
+    holdings = [{'symbol': r[0], 'quantity': r[1]} for r in rows]
+    if not holdings:
+        return {}
+    try:
+        from ..app import risk_metrics
+        metrics = risk_metrics.compute_portfolio_risk(holdings, days)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return metrics
+
+
+@app.get('/strategies')
+async def list_strategies():
+    """List available strategy files."""
+    files = []
+    strategy_dir = Path(__file__).resolve().parents[1] / 'strategies'
+    if strategy_dir.exists():
+        files = [f.name for f in strategy_dir.glob('*.py')]
+    return {'strategies': files}
+
+
+@app.get('/strategies/{name}')
+async def get_strategy(name: str):
+    """Return the contents of a strategy file."""
+    strategy_dir = Path(__file__).resolve().parents[1] / 'strategies'
+    path = strategy_dir / name
+    if not path.exists():
+        raise HTTPException(status_code=404, detail='Not found')
+    return {'name': name, 'code': path.read_text()}
+
+
 @app.get('/backtest/{symbol}')
 async def run_backtest_api(symbol: str, days: int = 90, key: str = Depends(require_key)):
     try:

--- a/strategies/sma_cross.py
+++ b/strategies/sma_cross.py
@@ -1,0 +1,19 @@
+"""Simple moving-average cross strategy."""
+
+def backtest(prices, short=5, long=20):
+    position = False
+    entry = 0
+    balance = 1.0
+    for i in range(long, len(prices)):
+        short_ma = sum(prices[i-short:i])/short
+        long_ma = sum(prices[i-long:i])/long
+        price = prices[i]
+        if not position and short_ma > long_ma:
+            position = True
+            entry = price
+        elif position and short_ma < long_ma:
+            balance *= price/entry
+            position = False
+    if position:
+        balance *= prices[-1]/entry
+    return balance-1


### PR DESCRIPTION
## Summary
- compute portfolio risk metrics (Sharpe ratio and max drawdown)
- expose `/portfolio/risk` endpoint
- add simple strategy marketplace endpoints and sample strategy
- document new features in README
- outline complementary roadmap ideas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e3a280d4c832b8ab72bdbb808d6e7

## Summary by Sourcery

Introduce portfolio risk analysis and a basic strategy marketplace with documentation updates

New Features:
- Compute portfolio-level Sharpe ratio and max drawdown metrics
- Add `/portfolio/risk` API endpoint to expose risk metrics
- Implement `/strategies` and `/strategies/{name}` endpoints with sample strategy file

Documentation:
- Update README to document risk metrics and strategy marketplace features
- Add complementary feature ideas in PROPOSAL_COMPLEMENT.md