### PR TITLE
Add assistant feature and cross-platform notifications

### DIFF
--- a/PROPOSAL_COMPLEMENT.md
+++ b/PROPOSAL_COMPLEMENT.md
@@ -7,3 +7,9 @@ Building upon the existing roadmap, the following additions could further streng
 3. **Natural Language Assistant** – chat-based helper for querying portfolio stats or strategy results.
 4. **Customisable Dashboards** – drag-and-drop widgets to tailor the web interface to user preferences.
 5. **Cross-Platform Alerts** – send notifications through Slack or Discord alongside email and Pushover.
+
+## Additional Ideas
+
+6. **User Permissions** – role-based access control to limit who can modify portfolio holdings or run backtests.
+7. **Scheduling UI** – calendar interface to adjust screener frequency and backtest windows visually.
+8. **Social Sentiment Feeds** – surface trending Twitter or Reddit discussions for watched symbols.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ results are stored:
 
 - `PUSHOVER_TOKEN` and `PUSHOVER_USER` for [Pushover](https://pushover.net) messages
 - `SMTP_SERVER`, `SMTP_USER`, `SMTP_PASS`, and `ALERT_EMAIL` for email alerts
+- `SLACK_WEBHOOK_URL` to post alerts to a Slack channel
+- `DISCORD_WEBHOOK_URL` to send alerts to Discord
 
 ## New Features
 - **Real-Time WebSockets**: Subscribe to `/ws/results` for instant screener updates.
@@ -163,3 +165,6 @@ results are stored:
 - **iCloud Sync**: The macOS companion stores your watchlist in iCloud for seamless access.
 - **Auto-Update**: The companion app checks a remote JSON file and prompts when a newer version is available.
 - **Strategy Marketplace**: Browse sample strategies via `/strategies` and view details at `/strategies/{name}`.
+- **Natural Language Assistant**: Query `/assistant` with a question about PnL, risk or strategies.
+- **Customisable Dashboards**: Drag widgets on the web UI to rearrange and store your layout.
+- **Cross-Platform Alerts**: Slack and Discord webhooks join email and Pushover notifications.

--- a/crypto_screener_ai/web/dashboard.py
+++ b/crypto_screener_ai/web/dashboard.py
@@ -80,9 +80,33 @@ def send_email(subject: str, body: str):
         logger.warning('Email alert failed: %s', exc)
 
 
+def send_slack(message: str):
+    """Send a Slack message via webhook if configured."""
+    url = os.getenv('SLACK_WEBHOOK_URL')
+    if not url:
+        return
+    try:
+        requests.post(url, json={'text': message}, timeout=10)
+    except Exception as exc:
+        logger.warning('Slack alert failed: %s', exc)
+
+
+def send_discord(message: str):
+    """Send a Discord message via webhook if configured."""
+    url = os.getenv('DISCORD_WEBHOOK_URL')
+    if not url:
+        return
+    try:
+        requests.post(url, json={'content': message}, timeout=10)
+    except Exception as exc:
+        logger.warning('Discord alert failed: %s', exc)
+
+
 def notify(message: str):
     send_push(message)
     send_email('CryptoScreenerAI Alert', message)
+    send_slack(message)
+    send_discord(message)
 
 
 def get_db():
@@ -288,6 +312,25 @@ async def run_backtest_api(symbol: str, days: int = 90, key: str = Depends(requi
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
     return result
+
+
+@app.post('/assistant')
+async def assistant(query: dict, key: str = Depends(require_key)):
+    """Very small natural-language helper for portfolio queries."""
+    text = query.get('query', '').lower()
+    if 'pnl' in text or 'p&l' in text:
+        pnl = await portfolio_pnl(key)
+        total = sum(item['pnl'] for item in pnl)
+        return {'response': f'Total PnL is {total:.2f} USD'}
+    if 'risk' in text:
+        risk = await portfolio_risk(key)
+        if not risk:
+            return {'response': 'No holdings recorded.'}
+        return {'response': f"Sharpe {risk.get('sharpe_ratio',0)}, Max DD {risk.get('max_drawdown',0)}"}
+    if 'strategy' in text:
+        strategies = (await list_strategies())['strategies']
+        return {'response': 'Available strategies: ' + ', '.join(strategies)}
+    return {'response': "I'm sorry, I can only answer questions about PnL, risk or strategies."}
 
 
 @app.get('/health')

--- a/crypto_screener_ai/web/frontend/index.html
+++ b/crypto_screener_ai/web/frontend/index.html
@@ -7,21 +7,90 @@
   <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
   <style>
     body { font-family: sans-serif; margin: 1rem; }
-    #content { max-width: 900px; margin: auto; }
+    #widgets { max-width: 900px; margin: auto; display: flex; flex-wrap: wrap; gap: 1rem; }
+    .widget { border: 1px solid #ccc; padding: 0.5rem; width: 280px; }
   </style>
 </head>
 <body>
   <h1>CryptoScreenerAI Dashboard</h1>
-  <div id="content"></div>
+  <div id="widgets">
+    <div class="widget" draggable="true" data-widget="results">
+      <h2>Latest Results</h2>
+      <pre id="latest"></pre>
+    </div>
+    <div class="widget" draggable="true" data-widget="pnl">
+      <h2>Portfolio PnL</h2>
+      <pre id="pnl"></pre>
+    </div>
+    <div class="widget" draggable="true" data-widget="assistant">
+      <h2>Assistant</h2>
+      <input id="question" placeholder="Ask about pnl, risk or strategies" />
+      <button onclick="ask()">Send</button>
+      <pre id="answer"></pre>
+    </div>
+  </div>
   <script>
-    async function loadLatest() {
-      const resp = await fetch('/results/latest', {headers:{'X-API-Key': 'demo'}});
-      const data = await resp.json();
-      const pre = document.createElement('pre');
-      pre.textContent = JSON.stringify(data, null, 2);
-      document.getElementById('content').appendChild(pre);
+    const KEY = 'demo';
+    const layoutKey = 'dashboardOrder';
+
+    function saveLayout() {
+      const order = Array.from(document.querySelectorAll('.widget')).map(w => w.dataset.widget);
+      localStorage.setItem(layoutKey, JSON.stringify(order));
     }
+
+    function loadLayout() {
+      const order = JSON.parse(localStorage.getItem(layoutKey) || '[]');
+      const container = document.getElementById('widgets');
+      order.forEach(name => {
+        const el = document.querySelector(`[data-widget="${name}"]`);
+        if (el) container.appendChild(el);
+      });
+    }
+
+    function enableDrag() {
+      document.querySelectorAll('.widget').forEach(w => {
+        w.addEventListener('dragstart', e => {
+          e.dataTransfer.setData('text/plain', w.dataset.widget);
+        });
+        w.addEventListener('dragover', e => e.preventDefault());
+        w.addEventListener('drop', e => {
+          e.preventDefault();
+          const from = document.querySelector(`[data-widget="${e.dataTransfer.getData('text/plain')}"]`);
+          if (from && from !== w) {
+            w.after(from);
+            saveLayout();
+          }
+        });
+      });
+    }
+
+    async function loadLatest() {
+      const resp = await fetch('/results/latest', {headers:{'X-API-Key': KEY}});
+      const data = await resp.json();
+      document.getElementById('latest').textContent = JSON.stringify(data, null, 2);
+    }
+
+    async function loadPnl() {
+      const resp = await fetch('/portfolio/pnl', {headers:{'X-API-Key': KEY}});
+      const data = await resp.json();
+      document.getElementById('pnl').textContent = JSON.stringify(data, null, 2);
+    }
+
+    async function ask() {
+      const q = document.getElementById('question').value;
+      const resp = await fetch('/assistant', {
+        method: 'POST',
+        headers:{'Content-Type':'application/json','X-API-Key': KEY},
+        body: JSON.stringify({query:q})
+      });
+      const data = await resp.json();
+      document.getElementById('answer').textContent = data.response;
+    }
+
+    loadLayout();
+    enableDrag();
     loadLatest();
+    loadPnl();
   </script>
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ plotly
 rich
 scikit-learn
 sqlalchemy
+slack_sdk
+discord-webhook


### PR DESCRIPTION
## Summary
- add Slack and Discord alerts
- implement natural language assistant endpoint
- allow drag-and-drop dashboard widgets
- document new environment variables and features
- propose additional complementary features
- bump requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e3d7b7a60832b9b258cef154be1db

## Summary by Sourcery

Add a natural-language assistant endpoint, support Slack/Discord alerts, and enable customizable drag-and-drop dashboard widgets with layout persistence; update documentation and dependencies accordingly.

New Features:
- Introduce a POST /assistant endpoint for natural-language portfolio queries (PnL, risk, strategies).
- Enable drag-and-drop dashboard widgets in the frontend with persistent layout storage.
- Send alert notifications to Slack and Discord via configurable webhooks.

Enhancements:
- Extend notification flow to include Slack and Discord alongside email and push alerts.

Documentation:
- Document SLACK_WEBHOOK_URL and DISCORD_WEBHOOK_URL environment variables in README.
- Update feature list in README and PROPOSAL_COMPLEMENT with assistant, dashboard, and cross-platform alerts.

Chores:
- Bump dependencies by adding slack_sdk and discord-webhook to requirements.txt.