### PR TITLE
Add user permissions and social sentiment feed

### DIFF
--- a/PROPOSAL_NEW_FEATURES.md
+++ b/PROPOSAL_NEW_FEATURES.md
@@ -1,0 +1,10 @@
+# Proposed Enhancements
+
+The recent updates introduce user permissions, a scheduling API and social sentiment feeds.
+To further complement these capabilities, consider the following ideas:
+
+1. **Mobile Push Notifications** – integrate native iOS/Android push services so alerts reach users instantly on their phones.
+2. **Multi-Language Support** – allow the dashboard UI to switch languages via simple JSON translation files.
+3. **Strategy Backtest Sharing** – users can publish backtest results with a shareable link for peer review.
+
+These additions would expand usability across different regions and devices while fostering collaboration among traders.

--- a/README.md
+++ b/README.md
@@ -168,3 +168,6 @@ results are stored:
 - **Natural Language Assistant**: Query `/assistant` with a question about PnL, risk or strategies.
 - **Customisable Dashboards**: Drag widgets on the web UI to rearrange and store your layout.
 - **Cross-Platform Alerts**: Slack and Discord webhooks join email and Pushover notifications.
+- **User Permissions**: Create API keys with roles via `/users` and restrict modifications to admins.
+- **Scheduling API**: Adjust screener frequency through `/schedule/screener`.
+- **Social Sentiment Feeds**: `/sentiment/posts` returns trending Reddit headlines.

--- a/crypto_screener_ai/web/dashboard.py
+++ b/crypto_screener_ai/web/dashboard.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title='CryptoScreenerAI Dashboard')
 
 SENTIMENT_DATA = {'sentiment': 'neutral', 'score': 0.0}
+SOCIAL_POSTS: list[str] = []
 
 # websocket state
 connections: set[WebSocket] = set()
@@ -121,12 +122,29 @@ def get_db():
                         quantity REAL,
                         entry_price REAL
                     )''')
+    conn.execute('''CREATE TABLE IF NOT EXISTS users (
+                        api_key TEXT PRIMARY KEY,
+                        role TEXT
+                    )''')
     return conn
 
 
-def require_key(key: str = Depends(api_key_header)):
-    if key != API_KEY:
-        raise HTTPException(status_code=401, detail='Invalid API key')
+def require_key(key: str = Depends(api_key_header)) -> dict:
+    """Validate API key and return user info."""
+    conn = get_db()
+    cur = conn.execute('SELECT role FROM users WHERE api_key = ?', (key,))
+    row = cur.fetchone()
+    conn.close()
+    if row:
+        return {'api_key': key, 'role': row[0]}
+    if key == API_KEY:
+        return {'api_key': key, 'role': 'admin'}
+    raise HTTPException(status_code=401, detail='Invalid API key')
+
+def require_admin(user: dict = Depends(require_key)) -> dict:
+    if user.get('role') != 'admin':
+        raise HTTPException(status_code=403, detail='Admin role required')
+    return user
 
 
 @app.get('/', response_class=HTMLResponse)
@@ -205,6 +223,12 @@ async def sentiment():
     return SENTIMENT_DATA
 
 
+@app.get('/sentiment/posts')
+async def sentiment_posts():
+    """Return cached list of trending social posts."""
+    return {'posts': SOCIAL_POSTS}
+
+
 @app.get('/predict/{symbol}')
 async def predict(symbol: str):
     """Dummy short-term price prediction."""
@@ -222,7 +246,7 @@ async def get_portfolio(key: str = Depends(require_key)):
 
 
 @app.post('/portfolio')
-async def upsert_portfolio(item: dict, key: str = Depends(require_key)):
+async def upsert_portfolio(item: dict, user: dict = Depends(require_admin)):
     symbol = item.get('symbol', '').upper()
     qty = float(item.get('quantity', 0))
     entry = float(item.get('entry_price', 0))
@@ -237,7 +261,7 @@ async def upsert_portfolio(item: dict, key: str = Depends(require_key)):
 
 
 @app.delete('/portfolio/{symbol}')
-async def delete_portfolio(symbol: str, key: str = Depends(require_key)):
+async def delete_portfolio(symbol: str, user: dict = Depends(require_admin)):
     conn = get_db()
     conn.execute('DELETE FROM portfolio WHERE symbol = ?', (symbol.upper(),))
     conn.commit()
@@ -305,8 +329,38 @@ async def get_strategy(name: str):
     return {'name': name, 'code': path.read_text()}
 
 
+@app.get('/users')
+async def list_users(user: dict = Depends(require_admin)):
+    """List registered API keys and roles."""
+    conn = get_db()
+    rows = conn.execute('SELECT api_key, role FROM users').fetchall()
+    conn.close()
+    return [{'api_key': r[0], 'role': r[1]} for r in rows]
+
+
+@app.post('/users/{api_key}')
+async def upsert_user(api_key: str, data: dict, user: dict = Depends(require_admin)):
+    """Create or update a user with the given API key."""
+    role = data.get('role', 'user')
+    conn = get_db()
+    conn.execute('INSERT OR REPLACE INTO users(api_key, role) VALUES(?,?)', (api_key, role))
+    conn.commit()
+    conn.close()
+    return {'status': 'ok'}
+
+
+@app.delete('/users/{api_key}')
+async def delete_user(api_key: str, user: dict = Depends(require_admin)):
+    """Remove a user by API key."""
+    conn = get_db()
+    conn.execute('DELETE FROM users WHERE api_key = ?', (api_key,))
+    conn.commit()
+    conn.close()
+    return {'status': 'ok'}
+
+
 @app.get('/backtest/{symbol}')
-async def run_backtest_api(symbol: str, days: int = 90, key: str = Depends(require_key)):
+async def run_backtest_api(symbol: str, days: int = 90, user: dict = Depends(require_admin)):
     try:
         result = backtest.run_backtest(symbol, days)
     except Exception as exc:
@@ -345,6 +399,22 @@ async def health():
     return {'run_id': row[0], 'ts': row[1]}
 
 
+@app.get('/schedule/screener')
+async def get_screener_schedule(user: dict = Depends(require_admin)):
+    """Return next scheduled screener run."""
+    job = scheduler.get_job('screener')
+    ts = job.next_run_time.isoformat() if job and job.next_run_time else None
+    return {'next_run': ts}
+
+
+@app.post('/schedule/screener')
+async def set_screener_schedule(data: dict, user: dict = Depends(require_admin)):
+    """Adjust interval for the screener job in hours."""
+    hours = float(data.get('hours', 1))
+    scheduler.reschedule_job('screener', trigger='interval', hours=hours)
+    return {'status': 'ok'}
+
+
 def screener_job():
     logger.info('Running screener job')
     run_screener.main()
@@ -368,10 +438,25 @@ def fetch_sentiment():
     logger.info('Fetched sentiment: %s', SENTIMENT_DATA)
 
 
+def fetch_social_posts():
+    """Fetch trending Reddit posts as a simple sentiment feed."""
+    global SOCIAL_POSTS
+    url = 'https://www.reddit.com/r/CryptoCurrency/top.json?limit=5&t=day'
+    try:
+        res = requests.get(url, headers={'User-Agent': 'CryptoScreenerAI'}, timeout=10)
+        res.raise_for_status()
+        data = res.json()
+        SOCIAL_POSTS = [child['data']['title'] for child in data['data']['children']]
+        logger.info('Fetched %d social posts', len(SOCIAL_POSTS))
+    except Exception as exc:
+        logger.warning('Social posts update failed: %s', exc)
+
+
 scheduler = BackgroundScheduler(
     jobstores={'default': SQLAlchemyJobStore(url=f'sqlite:///{DB_PATH / "jobs.db"}')}
 )
-scheduler.add_job(screener_job, 'interval', hours=1)
-scheduler.add_job(fetch_sentiment, 'interval', minutes=10)
+scheduler.add_job(screener_job, 'interval', hours=1, id='screener')
+scheduler.add_job(fetch_sentiment, 'interval', minutes=10, id='sentiment')
+scheduler.add_job(fetch_social_posts, 'interval', minutes=15, id='social')
 scheduler.start()
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,138 @@
+import sys
+import sys
+import types
+import importlib
+from pathlib import Path
+import pytest
+
+
+class DummyHTTPException(Exception):
+    def __init__(self, status_code: int = 500, detail: str | None = None):
+        self.status_code = status_code
+        self.detail = detail
+
+
+def load_dashboard(tmp_path):
+    # mock requests
+    dummy_requests = types.ModuleType('requests')
+    class DummyResponse:
+        def __init__(self, data, raise_exc=False):
+            self._data = data
+            self.raise_exc = raise_exc
+        def json(self):
+            if self.raise_exc:
+                raise ValueError('bad json')
+            return self._data
+        def raise_for_status(self):
+            if self.raise_exc:
+                raise Exception('err')
+    dummy_requests.Response = DummyResponse
+    dummy_requests._next_response = DummyResponse({'data':{'children':[{'data':{'title':'post1'}}]}})
+    def get(*args, **kwargs):
+        return dummy_requests._next_response
+    dummy_requests.get = get
+    sys.modules['requests'] = dummy_requests
+
+    dummy_dotenv = types.ModuleType('dotenv')
+    dummy_dotenv.load_dotenv = lambda *a, **k: None
+    sys.modules['dotenv'] = dummy_dotenv
+
+    dummy_rich = types.ModuleType('rich')
+    dummy_rich.print = lambda *a, **k: None
+    sys.modules['rich'] = dummy_rich
+
+    dummy_openai = types.ModuleType('openai')
+    class DummyCompletions:
+        def create(self, **kwargs):
+            class Msg:
+                content = '{}'
+            class Choice:
+                message = Msg()
+            class Resp:
+                choices = [Choice()]
+            return Resp()
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self.chat = types.SimpleNamespace(completions=DummyCompletions())
+    dummy_openai.OpenAI = DummyClient
+    sys.modules['openai'] = dummy_openai
+
+    # mock fastapi
+    dummy_fastapi = types.ModuleType('fastapi')
+    class DummyApp:
+        def __init__(self, *a, **k):
+            pass
+        def on_event(self, *a, **k):
+            def deco(fn):
+                return fn
+            return deco
+        def get(self, *a, **k):
+            return self.on_event()
+        def post(self, *a, **k):
+            return self.on_event()
+        def delete(self, *a, **k):
+            return self.on_event()
+        def websocket(self, *a, **k):
+            return self.on_event()
+    dummy_fastapi.FastAPI = DummyApp
+    dummy_fastapi.Depends = lambda x: x
+    dummy_fastapi.HTTPException = DummyHTTPException
+    dummy_fastapi.WebSocket = object
+    dummy_fastapi.WebSocketDisconnect = Exception
+    responses_mod = types.ModuleType('fastapi.responses')
+    responses_mod.HTMLResponse = object
+    responses_mod.StreamingResponse = object
+    sys.modules['fastapi.responses'] = responses_mod
+    security_mod = types.ModuleType('fastapi.security.api_key')
+    security_mod.APIKeyHeader = lambda name: None
+    sys.modules['fastapi.security.api_key'] = security_mod
+    dummy_fastapi.responses = responses_mod
+    dummy_fastapi.security = types.SimpleNamespace(api_key=security_mod)
+    sys.modules['fastapi'] = dummy_fastapi
+
+    # mock apscheduler
+    sched_mod = types.ModuleType('apscheduler.schedulers.background')
+    class DummyScheduler:
+        def __init__(self, *a, **k):
+            pass
+        def add_job(self, *a, **k):
+            pass
+        def start(self):
+            pass
+        def get_job(self, *a, **k):
+            return types.SimpleNamespace(next_run_time=None)
+        def reschedule_job(self, *a, **k):
+            pass
+    sched_mod.BackgroundScheduler = DummyScheduler
+    sys.modules['apscheduler.schedulers.background'] = sched_mod
+
+    jobstore_mod = types.ModuleType('apscheduler.jobstores.sqlalchemy')
+    jobstore_mod.SQLAlchemyJobStore = lambda url=None: None
+    sys.modules['apscheduler.jobstores.sqlalchemy'] = jobstore_mod
+
+    # ensure fresh import
+    sys.modules.pop('crypto_screener_ai.app.run_screener', None)
+    mod = importlib.import_module('crypto_screener_ai.web.dashboard')
+    mod.DB_FILE = Path(tmp_path) / 'test.db'
+    # clean up to avoid side effects
+    for name in ['requests', 'dotenv', 'rich', 'openai', 'fastapi', 'fastapi.responses',
+                 'fastapi.security.api_key', 'apscheduler.schedulers.background',
+                 'apscheduler.jobstores.sqlalchemy']:
+        sys.modules.pop(name, None)
+    return mod
+
+
+def test_fetch_social_posts_success(tmp_path):
+    mod = load_dashboard(tmp_path)
+    mod.fetch_social_posts()
+    assert mod.SOCIAL_POSTS == ['post1']
+
+
+def test_require_admin_denied(tmp_path):
+    mod = load_dashboard(tmp_path)
+    conn = mod.get_db()
+    conn.execute('INSERT INTO users(api_key, role) VALUES (?,?)', ('userkey', 'user'))
+    conn.commit()
+    conn.close()
+    with pytest.raises(DummyHTTPException):
+        mod.require_admin({'api_key': 'userkey', 'role': 'user'})


### PR DESCRIPTION
## Summary
- extend dashboard DB with `users` table
- add role-based API key validation and admin-only endpoints
- provide user management routes `/users` for API key administration
- expose `/sentiment/posts` endpoint and scheduled fetch of trending Reddit posts
- allow schedule adjustments via `/schedule/screener`
- document new features in README
- add tests for sentiment feed and permission checks
- propose further enhancements in `PROPOSAL_NEW_FEATURES.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e401f11f0832bbcbdac59ed778ca0

## Summary by Sourcery

Extend the dashboard with role-based access control and user management, introduce a scheduled Reddit sentiment feed, and enable dynamic adjustment of screener job scheduling.

New Features:
- Role-based API key management via `/users` endpoints
- Scheduled fetching of trending Reddit posts with `/sentiment/posts` endpoint
- Adjustable screener interval through `/schedule/screener` API

Enhancements:
- Enforce admin-only access for portfolio and backtest operations
- Integrate social posts job into the background scheduler

Documentation:
- Update README with user permissions, scheduling API, and sentiment feed
- Add PROPOSAL_NEW_FEATURES.md outlining future enhancement ideas

Tests:
- Add unit tests for social feed fetching and admin permission enforcement