### PR TITLE
Add security audit and offline mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Added changelog and proposal links in documentation.
 - Expanded feature proposal list.
+- Implemented security audit CLI and `/audit` endpoint.
+- Added offline mode using cached data when `OFFLINE_MODE` is set.
+- Created community strategy hub with share and rating endpoints.
 
 ## [0.1.0] - 2024-03-01
 - Initial release with CLI screener and dashboard.

--- a/PROPOSAL_COMPLEMENT.md
+++ b/PROPOSAL_COMPLEMENT.md
@@ -13,3 +13,6 @@ Building upon the existing roadmap, the following additions could further streng
 6. **User Permissions** – role-based access control to limit who can modify portfolio holdings or run backtests.
 7. **Scheduling UI** – calendar interface to adjust screener frequency and backtest windows visually.
 8. **Social Sentiment Feeds** – surface trending Twitter or Reddit discussions for watched symbols.
+9. **Multi-Factor Authentication** – secure logins with TOTP or hardware keys.
+10. **Strategy Versioning** – track revisions of user-submitted strategies in the community hub.
+11. **Data Export Tools** – allow CSV/JSON exports of backtest and portfolio metrics for external analysis.

--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ Output strictly conforms to the schema.
 
 
 ## Autorun
-Run `./autorun.sh` to install dependencies from `requirements.txt` and launch
-the dashboard. The API starts on port **9999**, while static files are served on
-port **9998**.
+Run `./setup.sh` to install dependencies, run a quick security audit and
+launch the dashboard. The API starts on port **9999**, while static files are
+served on port **9998**.
 
 ### Alerts
 Set these optional environment variables for push/email notifications when new
@@ -172,5 +172,8 @@ results are stored:
 - **User Permissions**: Create API keys with roles via `/users` and restrict modifications to admins.
 - **Scheduling API**: Adjust screener frequency through `/schedule/screener`.
 - **Social Sentiment Feeds**: `/sentiment/posts` returns trending Reddit headlines.
+- **Automated Security Audits**: `/audit` checks strategies and dependencies for issues.
+- **Offline Mode**: set `OFFLINE_MODE=1` to use cached data when the network is unavailable.
+- **Community Strategy Hub**: share and rate strategies via `/community/strategies`.
 
 See CHANGELOG.md for release history and PROPOSAL_NEW_FEATURES.md for upcoming ideas.

--- a/crypto_screener_ai/app/run_screener.py
+++ b/crypto_screener_ai/app/run_screener.py
@@ -8,8 +8,11 @@ New features:
   • Adds Task 8 asking for five best ideas in next 30 min
 """
 import json, os, uuid, datetime, argparse, requests, time
-
 from pathlib import Path
+
+CACHE_DIR = Path(__file__).resolve().parents[1] / 'data'
+CACHE_DIR.mkdir(exist_ok=True)
+TOP25_CACHE = CACHE_DIR / 'top25_cache.json'
 from dotenv import load_dotenv
 from rich import print
 from openai import OpenAI
@@ -23,7 +26,10 @@ def validate_schema(data: dict, schema_path: Path) -> None:
             raise ValueError(f"missing required key: {key}")
 
 def fetch_top_25_volume(vs_currency: str = "usd", retries: int = 3) -> list[str]:
-    """Fetch top 25 coins by volume with exponential backoff."""
+    """Fetch top 25 coins by volume with exponential backoff.
+    Falls back to cached data when OFFLINE_MODE is enabled or on failure."""
+    if os.getenv("OFFLINE_MODE") == "1" and TOP25_CACHE.exists():
+        return json.loads(TOP25_CACHE.read_text())
     url = (
         "https://api.coingecko.com/api/v3/coins/markets"
         f"?vs_currency={vs_currency}&order=volume_desc&per_page=25&page=1"
@@ -41,6 +47,8 @@ def fetch_top_25_volume(vs_currency: str = "usd", retries: int = 3) -> list[str]
             else:
                 time.sleep(delay)
                 delay *= 2
+    if TOP25_CACHE.exists():
+        return json.loads(TOP25_CACHE.read_text())
     return []
 
 # ---------- main --------------------------------------------------------------
@@ -95,15 +103,18 @@ def main():
         {"role": "assistant", "content": "Return JSON only."}
     ]
 
-    print("[bold cyan]🚀  Requesting analysis …[/]")
-    response = client.chat.completions.create(
-        model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
-        messages=messages,
-        temperature=0.3,
-        max_tokens=2800
-    )
-
-    reply = response.choices[0].message.content
+    if os.getenv("OFFLINE_MODE") == "1" and Path("last_response.json").exists():
+        print("[yellow]Offline mode enabled – using cached LLM response.[/]")
+        reply = Path("last_response.json").read_text()
+    else:
+        print("[bold cyan]🚀  Requesting analysis …[/]")
+        response = client.chat.completions.create(
+            model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+            messages=messages,
+            temperature=0.3,
+            max_tokens=2800
+        )
+        reply = response.choices[0].message.content
     schema_path = Path(__file__).with_name("schema.json")
     try:
         data = json.loads(reply)

--- a/crypto_screener_ai/app/security_audit.py
+++ b/crypto_screener_ai/app/security_audit.py
@@ -1,0 +1,68 @@
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+
+def audit_strategy_file(path: Path) -> list[str]:
+    """Return a list of warnings for a strategy file."""
+    warnings: list[str] = []
+    text = path.read_text()
+    if 'eval(' in text or 'exec(' in text:
+        warnings.append('uses eval/exec')
+    if 'os.system' in text:
+        warnings.append('uses os.system')
+    try:
+        ast.parse(text)
+    except SyntaxError as exc:
+        warnings.append(f'syntax error: {exc}')
+    return warnings
+
+
+def audit_strategies() -> dict[str, list[str]]:
+    """Audit all strategies in the strategies folder."""
+    strategy_dir = Path(__file__).resolve().parents[1] / 'strategies'
+    report = {}
+    for f in strategy_dir.glob('*.py'):
+        warns = audit_strategy_file(f)
+        if warns:
+            report[f.name] = warns
+    return report
+
+
+def audit_dependencies() -> list[str]:
+    """Return a list of packages with pre-release versions."""
+    try:
+        res = subprocess.run(
+            [sys.executable, '-m', 'pip', 'list', '--format', 'json'],
+            capture_output=True, text=True, check=True
+        )
+        packages = __import__('json').loads(res.stdout)
+    except Exception:
+        return []
+    flagged = []
+    for pkg in packages:
+        ver = pkg.get('version', '')
+        if 'a' in ver or 'b' in ver or 'rc' in ver:
+            flagged.append(f"{pkg['name']} {ver}")
+    return flagged
+
+
+def main() -> int:
+    strat_report = audit_strategies()
+    dep_report = audit_dependencies()
+    if strat_report:
+        print('Strategy Issues:')
+        for name, warns in strat_report.items():
+            print(f' - {name}: {", ".join(warns)}')
+    if dep_report:
+        print('Dependency Warnings:')
+        for pkg in dep_report:
+            print(f' - {pkg}')
+    if not strat_report and not dep_report:
+        print('No issues found.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/crypto_screener_ai/web/dashboard.py
+++ b/crypto_screener_ai/web/dashboard.py
@@ -15,7 +15,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 import csv
 
-from ..app import run_screener, backtest
+from ..app import run_screener, backtest, security_audit
 
 DB_PATH = Path(__file__).resolve().parents[1] / 'data'
 DB_PATH.mkdir(exist_ok=True)
@@ -125,6 +125,12 @@ def get_db():
     conn.execute('''CREATE TABLE IF NOT EXISTS users (
                         api_key TEXT PRIMARY KEY,
                         role TEXT
+                    )''')
+    conn.execute('''CREATE TABLE IF NOT EXISTS community_strategies (
+                        name TEXT PRIMARY KEY,
+                        code TEXT,
+                        rating REAL DEFAULT 0,
+                        votes INTEGER DEFAULT 0
                     )''')
     return conn
 
@@ -329,6 +335,58 @@ async def get_strategy(name: str):
     return {'name': name, 'code': path.read_text()}
 
 
+@app.get('/community/strategies')
+async def community_list():
+    conn = get_db()
+    rows = conn.execute('SELECT name, rating, votes FROM community_strategies').fetchall()
+    conn.close()
+    return [{'name': r[0], 'rating': r[1], 'votes': r[2]} for r in rows]
+
+
+@app.get('/community/strategies/{name}')
+async def community_get(name: str):
+    conn = get_db()
+    cur = conn.execute('SELECT name, code, rating, votes FROM community_strategies WHERE name = ?', (name,))
+    row = cur.fetchone()
+    conn.close()
+    if not row:
+        raise HTTPException(status_code=404, detail='Not found')
+    return {'name': row[0], 'code': row[1], 'rating': row[2], 'votes': row[3]}
+
+
+@app.post('/community/strategies')
+async def community_add(item: dict, user: dict = Depends(require_key)):
+    name = item.get('name')
+    code = item.get('code')
+    if not name or not code:
+        raise HTTPException(status_code=400, detail='name and code required')
+    conn = get_db()
+    conn.execute('INSERT OR REPLACE INTO community_strategies(name, code) VALUES (?,?)', (name, code))
+    conn.commit()
+    conn.close()
+    return {'status': 'ok'}
+
+
+@app.post('/community/strategies/{name}/rate')
+async def community_rate(name: str, data: dict, user: dict = Depends(require_key)):
+    rating = float(data.get('rating', 0))
+    if rating < 1 or rating > 5:
+        raise HTTPException(status_code=400, detail='rating 1-5')
+    conn = get_db()
+    cur = conn.execute('SELECT rating, votes FROM community_strategies WHERE name=?', (name,))
+    row = cur.fetchone()
+    if not row:
+        conn.close()
+        raise HTTPException(status_code=404, detail='Not found')
+    current_rating, votes = row
+    new_votes = votes + 1
+    new_rating = ((current_rating * votes) + rating) / new_votes
+    conn.execute('UPDATE community_strategies SET rating=?, votes=? WHERE name=?', (new_rating, new_votes, name))
+    conn.commit()
+    conn.close()
+    return {'status': 'ok', 'rating': round(new_rating, 2), 'votes': new_votes}
+
+
 @app.get('/users')
 async def list_users(user: dict = Depends(require_admin)):
     """List registered API keys and roles."""
@@ -397,6 +455,16 @@ async def health():
     if not row:
         return {'run_id': None, 'ts': None}
     return {'run_id': row[0], 'ts': row[1]}
+
+
+@app.get('/audit')
+async def audit(user: dict = Depends(require_admin)):
+    """Run basic security audit of strategies and dependencies."""
+    report = {
+        'strategies': security_audit.audit_strategies(),
+        'dependencies': security_audit.audit_dependencies(),
+    }
+    return report
 
 
 @app.get('/schedule/screener')

--- a/data/top25_cache.json
+++ b/data/top25_cache.json
@@ -1,0 +1,1 @@
+["BTC","ETH","BNB","XRP","SOL"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ scikit-learn
 sqlalchemy
 slack_sdk
 discord-webhook
+bandit

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+pip install -r requirements.txt
+python -m crypto_screener_ai.app.security_audit || true
+echo "Launching CryptoScreenerAI dashboard on ports 9999 (API) and 9998 (frontend)"
+python -m crypto_screener_ai.web.run_dashboard


### PR DESCRIPTION
## Summary
- add a simple security audit module
- support offline mode using cached data
- introduce community strategy hub endpoints
- document new features and proposals
- add setup.sh helper and bandit requirement

## Testing
- `pytest -q`
- `python -m crypto_screener_ai.app.security_audit`

------
https://chatgpt.com/codex/tasks/task_e_685e4a3c45a0832b92353409765e7330

## Summary by Sourcery

Add security audit capabilities, offline mode support, and a community strategy hub, along with helper scripts and documentation updates.

New Features:
- Introduce security audit module with CLI and /audit API endpoint for strategies and dependencies
- Enable offline mode to use cached market data and LLM responses when network is unavailable
- Implement community strategy hub with endpoints to share, list, retrieve, and rate strategies
- Add setup.sh script to install dependencies, run a security audit, and launch the dashboard

Enhancements:
- Fallback to cached top-25 coin data and cached LLM responses when OFFLINE_MODE is enabled

Build:
- Add bandit security linter to project dependencies

Documentation:
- Update README with instructions for security audit, offline mode, and community strategy hub
- Revise CHANGELOG and proposal documents to reflect the new features