### PR TITLE
Implement analytics dashboard

### DIFF
--- a/crypto_screener_ai/web/dashboard.py
+++ b/crypto_screener_ai/web/dashboard.py
@@ -454,6 +454,39 @@ async def backtest_export(symbol: str, days: int = 90, format: str = 'json', use
     return result
 
 
+def compute_analytics(limit: int = 5) -> dict:
+    """Aggregate momentum scores from recent screener runs."""
+    conn = get_db()
+    cur = conn.execute('SELECT data FROM results ORDER BY ts DESC LIMIT ?', (limit,))
+    rows = cur.fetchall()
+    conn.close()
+    scores: dict[str, list[float]] = {}
+    for row in rows:
+        js = json.loads(row[0])
+        for sym, windows in js.get('screener', {}).items():
+            for win in windows.values():
+                scores.setdefault(sym, []).append(float(win.get('momentum_score', 0)))
+    return {sym: (sum(vals) / len(vals)) if vals else 0.0 for sym, vals in scores.items()}
+
+
+@app.get('/analytics/summary')
+async def analytics_summary(limit: int = 5, key: str = Depends(require_key)):
+    """Return average momentum score per symbol for recent runs."""
+    return compute_analytics(limit)
+
+
+@app.get('/analytics/report')
+async def analytics_report(limit: int = 5, key: str = Depends(require_key)):
+    """Return simple report highlighting top momentum symbols."""
+    summary = compute_analytics(limit)
+    top = sorted(summary.items(), key=lambda x: abs(x[1]), reverse=True)[:5]
+    return {
+        'top_symbols': [
+            {'symbol': sym, 'avg_momentum': round(score, 3)} for sym, score in top
+        ]
+    }
+
+
 @app.post('/assistant')
 async def assistant(query: dict, key: str = Depends(require_key)):
     """Very small natural-language helper for portfolio queries."""

--- a/crypto_screener_ai/web/frontend/index.html
+++ b/crypto_screener_ai/web/frontend/index.html
@@ -28,6 +28,10 @@
       <button onclick="ask()">Send</button>
       <pre id="answer"></pre>
     </div>
+    <div class="widget" draggable="true" data-widget="analytics">
+      <h2>Analytics</h2>
+      <div id="chart" style="width:260px;height:200px;"></div>
+    </div>
   </div>
   <script>
     const KEY = 'demo';
@@ -76,6 +80,15 @@
       document.getElementById('pnl').textContent = JSON.stringify(data, null, 2);
     }
 
+    async function loadAnalytics() {
+      const resp = await fetch('/analytics/summary', {headers:{'X-API-Key': KEY}});
+      const data = await resp.json();
+      const symbols = Object.keys(data);
+      const scores = symbols.map(s => data[s]);
+      const trace = {x: symbols, y: scores, type: 'bar'};
+      Plotly.newPlot('chart', [trace], {margin:{t:30}});
+    }
+
     async function ask() {
       const q = document.getElementById('question').value;
       const resp = await fetch('/assistant', {
@@ -91,6 +104,7 @@
     enableDrag();
     loadLatest();
     loadPnl();
+    loadAnalytics();
   </script>
 </body>
 </html>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,7 +1,7 @@
 import sys
-import sys
 import types
 import importlib
+import json
 from pathlib import Path
 import pytest
 
@@ -136,3 +136,26 @@ def test_require_admin_denied(tmp_path):
     conn.close()
     with pytest.raises(DummyHTTPException):
         mod.require_admin({'api_key': 'userkey', 'role': 'user'})
+
+
+def test_compute_analytics(tmp_path):
+    mod = load_dashboard(tmp_path)
+    conn = mod.get_db()
+    sample = {
+        'screener': {
+            'BTC': {
+                '1h': {'momentum_score': 0.5},
+                '4h': {'momentum_score': 0.3}
+            },
+            'ETH': {
+                '1h': {'momentum_score': -0.2}
+            }
+        }
+    }
+    conn.execute('INSERT INTO results(run_id, ts, data) VALUES (?,?,?)',
+                 ('id1', 't', json.dumps(sample)))
+    conn.commit()
+    conn.close()
+    summary = mod.compute_analytics()
+    assert round(summary['BTC'], 2) == 0.4
+    assert round(summary['ETH'], 2) == -0.2


### PR DESCRIPTION
## Summary
- add `compute_analytics` helper and `/analytics` API endpoints
- show analytics chart on the frontend
- test compute_analytics logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e51fff664832ba3ebabc3640e2510

## Summary by Sourcery

Implement an analytics dashboard by aggregating momentum scores from recent runs, exposing summary and report endpoints, and rendering the results in a frontend widget

New Features:
- Introduce compute_analytics helper to aggregate recent momentum scores
- Add /analytics/summary and /analytics/report endpoints to expose average and top momentum symbols
- Embed an analytics widget with a Plotly bar chart in the frontend dashboard

Tests:
- Add test_compute_analytics to verify average momentum score calculations