### PR TITLE
Add Streamlit trading bot dashboard

### DIFF
--- a/PROPOSAL_COMPLEMENT.md
+++ b/PROPOSAL_COMPLEMENT.md
@@ -18,3 +18,5 @@ Building upon the existing roadmap, the following additions could further streng
 11. **Data Export Tools** – allow CSV/JSON exports of backtest and portfolio metrics for external analysis.
 12. **Advanced Analytics Dashboard** – visualise results with interactive charts and custom reports.
 13. **Cloud Sync for Strategies** – store user strategies in a cloud drive for access across devices.
+14. **Paper Trading Mode** – simulate trades using live data without risking real funds.
+15. **Hardware Wallet Integration** – display balances from Ledger or Trezor devices within the dashboard.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,46 @@
+import streamlit as st
+import pandas as pd
+from trading_bot.data import DataFetcher
+from trading_bot.indicators import IndicatorCalculator
+from trading_bot.ml import PriceDirectionModel
+from trading_bot.backtest import SimpleStrategy
+
+st.set_page_config(page_title="Trading Bot Dashboard", layout="wide")
+
+symbol = st.sidebar.text_input("Trading Pair", "BTC/USDT")
+fetcher = DataFetcher(symbol)
+
+@st.cache_data(ttl=60)
+def load_data():
+    df = fetcher.get_ohlcv(timeframe='1h', limit=240)
+    calc = IndicatorCalculator(df)
+    df = calc.add_indicators()
+    df[['support','resistance']] = calc.support_resistance()
+    return df
+
+df = load_data()
+current_price = fetcher.get_current_price()
+
+st.sidebar.metric("Current Price", f"{current_price:.2f}")
+st.sidebar.metric("Latest RSI", f"{df['rsi'].iloc[-1]:.2f}")
+
+model = PriceDirectionModel()
+model.fit(df)
+prob = model.predict_proba(df)
+
+st.sidebar.write(f"**AI Buy Probability:** {prob*100:.1f}%")
+
+if st.button("Run Backtest"):
+    strategy = SimpleStrategy(df)
+    perf = strategy.run()
+    st.sidebar.write(f"Backtest Return: {perf}%")
+
+import plotly.graph_objects as go
+fig = go.Figure()
+fig.add_trace(go.Candlestick(x=df['timestamp'], open=df['open'], high=df['high'],
+                             low=df['low'], close=df['close'], name='Price'))
+fig.add_trace(go.Scatter(x=df['timestamp'], y=df['vwap'], name='VWAP'))
+fig.add_trace(go.Scatter(x=df['timestamp'], y=df['ma_20'], name='MA20'))
+fig.add_trace(go.Scatter(x=df['timestamp'], y=df['ma_50'], name='MA50'))
+fig.update_layout(height=600)
+st.plotly_chart(fig, use_container_width=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,8 @@ sqlalchemy
 slack_sdk
 discord-webhook
 bandit
+ccxt
+pandas
+pandas_ta
+streamlit
+transformers

--- a/tests/test_new_bot.py
+++ b/tests/test_new_bot.py
@@ -1,0 +1,45 @@
+import types
+import pytest
+pytest.importorskip('pandas')
+pytest.importorskip('pandas_ta')
+
+from trading_bot.data import DataFetcher
+from trading_bot.indicators import IndicatorCalculator
+from trading_bot.ml import PriceDirectionModel
+from trading_bot.backtest import SimpleStrategy
+
+class DummyExchange:
+    def fetch_ticker(self, symbol):
+        return {'last': 100.0}
+    def fetch_ohlcv(self, symbol, timeframe='1h', limit=10):
+        rows = []
+        for i in range(limit):
+            rows.append([i*3600000, 100+i, 101+i, 99+i, 100+i, 1])
+        return rows
+
+def test_data_fetcher(monkeypatch):
+    monkeypatch.setattr('ccxt.binance', lambda *a, **k: DummyExchange())
+    df = DataFetcher().get_ohlcv(limit=5)
+    assert len(df) == 5
+    assert 'close' in df.columns
+    price = DataFetcher().get_current_price()
+    assert price == 100.0
+
+def test_indicators_and_ml(monkeypatch):
+    monkeypatch.setattr('ccxt.binance', lambda *a, **k: DummyExchange())
+    df = DataFetcher().get_ohlcv(limit=30)
+    calc = IndicatorCalculator(df)
+    df = calc.add_indicators()
+    model = PriceDirectionModel()
+    model.fit(df)
+    prob = model.predict_proba(df)
+    assert 0 <= prob <= 1
+
+def test_backtest(monkeypatch):
+    monkeypatch.setattr('ccxt.binance', lambda *a, **k: DummyExchange())
+    df = DataFetcher().get_ohlcv(limit=30)
+    calc = IndicatorCalculator(df)
+    df = calc.add_indicators()
+    strat = SimpleStrategy(df)
+    result = strat.run()
+    assert isinstance(result, float)

--- a/trading_bot/__init__.py
+++ b/trading_bot/__init__.py
@@ -1,0 +1,14 @@
+"""Trading bot utilities."""
+from .data import DataFetcher
+from .indicators import IndicatorCalculator
+from .ml import PriceDirectionModel
+from .backtest import SimpleStrategy
+from .sentiment import analyze_sentiment
+
+__all__ = [
+    "DataFetcher",
+    "IndicatorCalculator",
+    "PriceDirectionModel",
+    "SimpleStrategy",
+    "analyze_sentiment",
+]

--- a/trading_bot/backtest.py
+++ b/trading_bot/backtest.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+class SimpleStrategy:
+    """Basic VWAP + RSI strategy for demonstration."""
+    def __init__(self, df: pd.DataFrame):
+        self.df = df
+
+    def run(self):
+        cash = 1.0
+        position = 0.0
+        entry = 0.0
+        for _, row in self.df.iterrows():
+            if position == 0 and row['close'] > row['vwap'] and row['rsi'] < 30:
+                position = cash / row['close']
+                entry = row['close']
+                cash = 0.0
+            elif position > 0 and (row['close'] < row['vwap'] or row['rsi'] > 70):
+                cash = position * row['close']
+                position = 0.0
+        if position > 0:
+            cash = position * self.df.iloc[-1]['close']
+        return round((cash - 1.0)*100, 2)

--- a/trading_bot/data.py
+++ b/trading_bot/data.py
@@ -1,0 +1,21 @@
+import ccxt
+import pandas as pd
+from typing import List
+
+class DataFetcher:
+    """Fetch market data from Binance via ccxt."""
+    def __init__(self, symbol: str = "BTC/USDT"):  
+        self.symbol = symbol
+        self.exchange = ccxt.binance({"enableRateLimit": True})
+
+    def get_current_price(self) -> float:
+        """Return last trade price."""
+        ticker = self.exchange.fetch_ticker(self.symbol)
+        return ticker['last']
+
+    def get_ohlcv(self, timeframe: str = '1h', limit: int = 500) -> pd.DataFrame:
+        """Return OHLCV data as a DataFrame."""
+        data = self.exchange.fetch_ohlcv(self.symbol, timeframe=timeframe, limit=limit)
+        df = pd.DataFrame(data, columns=['timestamp','open','high','low','close','volume'])
+        df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
+        return df

--- a/trading_bot/indicators.py
+++ b/trading_bot/indicators.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pandas_ta as ta
+
+class IndicatorCalculator:
+    """Calculate common trading indicators."""
+
+    def __init__(self, df: pd.DataFrame):
+        self.df = df.copy()
+
+    def add_indicators(self) -> pd.DataFrame:
+        df = self.df
+        # VWAP using pandas_ta
+        df['vwap'] = ta.vwap(df['high'], df['low'], df['close'], df['volume'])
+        # Moving averages
+        df['ma_20'] = ta.sma(df['close'], length=20)
+        df['ma_50'] = ta.sma(df['close'], length=50)
+        # RSI
+        df['rsi'] = ta.rsi(df['close'])
+        # ADX
+        df['adx'] = ta.adx(df['high'], df['low'], df['close'])['ADX_14']
+        # Bill Williams fractals
+        df['fractal_up'] = ta.fractals(df['high'], df['low'])['FRAU_2']
+        df['fractal_down'] = ta.fractals(df['high'], df['low'])['FRAD_2']
+        return df
+
+    def support_resistance(self, window: int = 20) -> pd.DataFrame:
+        df = self.df
+        df['support'] = df['low'].rolling(window=window).min()
+        df['resistance'] = df['high'].rolling(window=window).max()
+        return df[['support','resistance']]

--- a/trading_bot/ml.py
+++ b/trading_bot/ml.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import StandardScaler
+from sklearn.pipeline import make_pipeline
+
+class PriceDirectionModel:
+    """Train a simple logistic regression to predict next bar direction."""
+
+    def __init__(self):
+        self.model = make_pipeline(StandardScaler(), LogisticRegression())
+        self.is_fitted = False
+
+    def fit(self, df: pd.DataFrame) -> None:
+        df = df.dropna().copy()
+        df['target'] = (df['close'].shift(-1) > df['close']).astype(int)
+        features = df[['ma_20','ma_50','rsi','adx']].values
+        self.model.fit(features, df['target'])
+        self.is_fitted = True
+
+    def predict_proba(self, df: pd.DataFrame) -> float:
+        if not self.is_fitted:
+            return 0.5
+        last = df.dropna().iloc[-1]
+        X = last[['ma_20','ma_50','rsi','adx']].values.reshape(1, -1)
+        proba = self.model.predict_proba(X)[0,1]
+        return proba

--- a/trading_bot/sentiment.py
+++ b/trading_bot/sentiment.py
@@ -1,0 +1,10 @@
+from random import choice
+
+def analyze_sentiment(texts):
+    """Return a dummy sentiment score for a list of texts."""
+    if not texts:
+        return {"sentiment": "neutral", "score": 0.0}
+    # Placeholder: randomly choose sentiment
+    sentiment = choice(["positive", "neutral", "negative"])
+    score = {"positive": 0.7, "neutral": 0.0, "negative": -0.7}[sentiment]
+    return {"sentiment": sentiment, "score": score}


### PR DESCRIPTION
## Summary
- create new `trading_bot` package with data fetching, indicators, ML model and backtest logic
- build a minimal `app.py` Streamlit dashboard using those modules
- expand requirements with ccxt, pandas, pandas_ta, streamlit and transformers
- add complementary features to the proposal
- include basic tests for the new code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f6541eec8832bb49e0e34a76d5a46

## Summary by Sourcery

Add a new `trading_bot` package and accompanying Streamlit dashboard, expand dependencies, update proposal ideas, and include basic tests to enable data-driven trading analysis and backtesting.

New Features:
- Introduce a modular `trading_bot` package with data fetching, indicator computation, machine learning model, backtesting, and sentiment analysis utilities
- Add a Streamlit dashboard (`app.py`) to visualize market data, display metrics, run backtests, and show AI buy probability interactively

Enhancements:
- Cache dashboard data loading for performance

Build:
- Expand project dependencies with ccxt, pandas, pandas_ta, streamlit, and transformers

Documentation:
- Update proposal document with paper trading mode and hardware wallet integration suggestions

Tests:
- Add unit tests for data fetching, indicator calculations, ML prediction, and backtest logic