### PR TITLE
Fix Ruff issues and clean imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import streamlit as st
-import pandas as pd
+import plotly.graph_objects as go
 from trading_bot.data import DataFetcher
 from trading_bot.indicators import IndicatorCalculator
 from trading_bot.ml import PriceDirectionModel
@@ -34,8 +34,6 @@ if st.button("Run Backtest"):
     strategy = SimpleStrategy(df)
     perf = strategy.run()
     st.sidebar.write(f"Backtest Return: {perf}%")
-
-import plotly.graph_objects as go
 fig = go.Figure()
 fig.add_trace(go.Candlestick(x=df['timestamp'], open=df['open'], high=df['high'],
                              low=df['low'], close=df['close'], name='Price'))

--- a/crypto_screener_ai/app/run_screener.py
+++ b/crypto_screener_ai/app/run_screener.py
@@ -7,7 +7,12 @@ New features:
   • Automatically appends top-25-by-volume (CoinGecko) to the watch-list
   • Adds Task 8 asking for five best ideas in next 30 min
 """
-import json, os, uuid, datetime, argparse, requests
+import argparse
+import datetime
+import json
+import os
+import requests
+import uuid
 from pathlib import Path
 from dotenv import load_dotenv
 from rich import print

--- a/crypto_screener_ai/web/dashboard.py
+++ b/crypto_screener_ai/web/dashboard.py
@@ -13,7 +13,6 @@ from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.security.api_key import APIKeyHeader
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
-import csv
 
 from ..app import run_screener, backtest, security_audit
 

--- a/crypto_screener_ai/web/run_dashboard.py
+++ b/crypto_screener_ai/web/run_dashboard.py
@@ -2,8 +2,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-from . import dashboard
-
 
 def main():
     # run uvicorn on port 9999

--- a/tests/test_backtest_offline.py
+++ b/tests/test_backtest_offline.py
@@ -1,8 +1,10 @@
-import sys, os, json
+import importlib
+import json
+import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-import types, importlib
+import types
 
 
 def test_fetch_historical_prices_offline(tmp_path, monkeypatch):

--- a/tests/test_new_bot.py
+++ b/tests/test_new_bot.py
@@ -1,4 +1,3 @@
-import types
 import pytest
 pytest.importorskip('pandas')
 pytest.importorskip('pandas_ta')

--- a/trading_bot/backtest.py
+++ b/trading_bot/backtest.py
@@ -8,11 +8,9 @@ class SimpleStrategy:
     def run(self):
         cash = 1.0
         position = 0.0
-        entry = 0.0
         for _, row in self.df.iterrows():
             if position == 0 and row['close'] > row['vwap'] and row['rsi'] < 30:
                 position = cash / row['close']
-                entry = row['close']
                 cash = 0.0
             elif position > 0 and (row['close'] < row['vwap'] or row['rsi'] > 70):
                 cash = position * row['close']

--- a/trading_bot/data.py
+++ b/trading_bot/data.py
@@ -1,6 +1,5 @@
 import ccxt
 import pandas as pd
-from typing import List
 
 class DataFetcher:
     """Fetch market data from Binance via ccxt."""


### PR DESCRIPTION
## Summary
- resolve ruff warnings across project
- remove unused imports
- keep Plotly import at top of `app.py`
- split multi-import lines
- cleanup unused variable in `SimpleStrategy`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa2aaba60832b87d45845b0578266

## Summary by Sourcery

Clean up code by resolving Ruff linter warnings, organizing imports, and removing unused variables across the project.

Enhancements:
- Standardize and split import statements while removing unused imports in modules and tests
- Remove unused variables and redundant imports in backtest logic and data fetching
- Maintain the Plotly import at the top of app.py after cleanup