### PR TITLE
Implement offline cache for DataFetcher

### DIFF
--- a/PROPOSAL_EXTRA_FEATURES.md
+++ b/PROPOSAL_EXTRA_FEATURES.md
@@ -1,0 +1,10 @@
+# Additional Complementary Features
+
+To further enhance the Alerts Bot and CryptoScreenerAI ecosystem, consider the following ideas:
+
+1. **Automated Exchange Balances** – periodically sync account balances from supported exchanges to keep portfolio information current without manual input.
+2. **Price Anomaly Detector** – highlight sudden price spikes or drops across watchlisted assets using statistical outlier detection.
+3. **Webhook Trigger Rules** – let users define custom conditions (e.g., RSI crossing thresholds) that send a webhook notification or execute a script when met.
+4. **Custom Report Scheduler** – generate PDF or HTML summaries of backtest results and portfolio metrics on a weekly or monthly cadence.
+
+These additions would complement existing analytics and alerting functionality, providing more automation and actionable insights.

--- a/tests/test_data_offline.py
+++ b/tests/test_data_offline.py
@@ -1,0 +1,43 @@
+import sys
+import json
+import types
+from pathlib import Path
+import pytest
+pd = pytest.importorskip('pandas')
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from trading_bot.data import DataFetcher
+
+
+def test_data_fetcher_offline(monkeypatch):
+    # prepare cache files
+    price_cache = Path('data/price_btcusdt.json')
+    price_cache.write_text(json.dumps(123.45))
+    ohlcv_cache = Path('data/ohlcv_btcusdt_1h.csv')
+    df = pd.DataFrame({
+        'timestamp': pd.date_range('2024-01-01', periods=3, freq='H'),
+        'open': [1, 2, 3],
+        'high': [2, 3, 4],
+        'low': [0.5, 1.5, 2.5],
+        'close': [1.5, 2.5, 3.5],
+        'volume': [10, 20, 30]
+    })
+    df.to_csv(ohlcv_cache, index=False)
+
+    monkeypatch.setenv('OFFLINE_MODE', '1')
+
+    fetcher = DataFetcher('BTC/USDT')
+    fetcher.exchange = types.SimpleNamespace(
+        fetch_ticker=lambda *a, **k: (_ for _ in ()).throw(AssertionError('net')),
+        fetch_ohlcv=lambda *a, **k: (_ for _ in ()).throw(AssertionError('net'))
+    )
+
+    price = fetcher.get_current_price()
+    data = fetcher.get_ohlcv()
+
+    assert price == 123.45
+    assert len(data) == 3
+
+    price_cache.unlink()
+    ohlcv_cache.unlink()

--- a/trading_bot/data.py
+++ b/trading_bot/data.py
@@ -1,21 +1,62 @@
+import os
+import json
+from pathlib import Path
 import ccxt
 import pandas as pd
-from typing import List
 
 class DataFetcher:
-    """Fetch market data from Binance via ccxt."""
-    def __init__(self, symbol: str = "BTC/USDT"):  
+    """Fetch market data from Binance via ccxt with optional caching."""
+
+    def __init__(self, symbol: str = "BTC/USDT"):
         self.symbol = symbol
         self.exchange = ccxt.binance({"enableRateLimit": True})
+        self.cache_dir = Path(__file__).resolve().parents[1] / "data"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def _price_cache(self) -> Path:
+        sym = self.symbol.replace("/", "").lower()
+        return self.cache_dir / f"price_{sym}.json"
+
+    def _ohlcv_cache(self, timeframe: str) -> Path:
+        sym = self.symbol.replace("/", "").lower()
+        return self.cache_dir / f"ohlcv_{sym}_{timeframe}.csv"
 
     def get_current_price(self) -> float:
-        """Return last trade price."""
-        ticker = self.exchange.fetch_ticker(self.symbol)
-        return ticker['last']
+        """Return last trade price, using cache if OFFLINE_MODE is set."""
+        cache_path = self._price_cache()
+        if os.getenv("OFFLINE_MODE") and cache_path.exists():
+            return json.loads(cache_path.read_text())
 
-    def get_ohlcv(self, timeframe: str = '1h', limit: int = 500) -> pd.DataFrame:
-        """Return OHLCV data as a DataFrame."""
-        data = self.exchange.fetch_ohlcv(self.symbol, timeframe=timeframe, limit=limit)
-        df = pd.DataFrame(data, columns=['timestamp','open','high','low','close','volume'])
-        df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
-        return df
+        try:
+            ticker = self.exchange.fetch_ticker(self.symbol)
+            price = ticker["last"]
+            cache_path.write_text(json.dumps(price))
+            return price
+        except Exception:
+            if cache_path.exists():
+                return json.loads(cache_path.read_text())
+            raise
+
+    def get_ohlcv(self, timeframe: str = "1h", limit: int = 500) -> pd.DataFrame:
+        """Return OHLCV data as a DataFrame, using cache if OFFLINE_MODE is set."""
+        cache_path = self._ohlcv_cache(timeframe)
+        if os.getenv("OFFLINE_MODE") and cache_path.exists():
+            df = pd.read_csv(cache_path)
+            df["timestamp"] = pd.to_datetime(df["timestamp"])
+            return df.head(limit)
+
+        try:
+            data = self.exchange.fetch_ohlcv(self.symbol, timeframe=timeframe, limit=limit)
+            df = pd.DataFrame(
+                data,
+                columns=["timestamp", "open", "high", "low", "close", "volume"],
+            )
+            df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+            df.to_csv(cache_path, index=False)
+            return df
+        except Exception:
+            if cache_path.exists():
+                df = pd.read_csv(cache_path)
+                df["timestamp"] = pd.to_datetime(df["timestamp"])
+                return df.head(limit)
+            raise


### PR DESCRIPTION
## Summary
- enable cached price and OHLCV data when `OFFLINE_MODE` is set
- add tests covering the offline behaviour
- document additional complementary feature ideas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa2abdf04832b9671af4e8e36556f

## Summary by Sourcery

Implement optional offline mode for DataFetcher by caching market prices and OHLCV data to disk and reading from cache when OFFLINE_MODE is set, add fallback on API failures, include corresponding tests and supplemental feature documentation.

New Features:
- Enable offline caching of current price and OHLCV data in DataFetcher under OFFLINE_MODE

Enhancements:
- Automatically create a local data cache directory
- Fallback to stored cache on API errors when fetching market data

Documentation:
- Introduce PROPOSAL_EXTRA_FEATURES.md with additional feature proposals

Tests:
- Add tests to verify offline cache behavior for price and OHLCV retrieval