### PR TITLE
Fix backtest entry var

### DIFF
--- a/PROPOSAL_COMPLEMENT.md
+++ b/PROPOSAL_COMPLEMENT.md
@@ -20,3 +20,6 @@ Building upon the existing roadmap, the following additions could further streng
 13. **Cloud Sync for Strategies** – store user strategies in a cloud drive for access across devices.
 14. **Paper Trading Mode** – simulate trades using live data without risking real funds.
 15. **Hardware Wallet Integration** – display balances from Ledger or Trezor devices within the dashboard.
+16. **Custom Alert Sounds** – allow users to upload audio clips for personalized notifications.
+17. **Historical Market Snapshots** – store daily OHLCV data for offline research and backtests.
+18. **Strategy Performance Rankings** – leaderboard showing top strategies by ROI over various periods.

--- a/trading_bot/backtest.py
+++ b/trading_bot/backtest.py
@@ -8,11 +8,9 @@ class SimpleStrategy:
     def run(self):
         cash = 1.0
         position = 0.0
-        entry = 0.0
         for _, row in self.df.iterrows():
             if position == 0 and row['close'] > row['vwap'] and row['rsi'] < 30:
                 position = cash / row['close']
-                entry = row['close']
                 cash = 0.0
             elif position > 0 and (row['close'] < row['vwap'] or row['rsi'] > 70):
                 cash = position * row['close']


### PR DESCRIPTION
## Summary
- remove unused `entry` variable from `SimpleStrategy`
- note extra complementary features in `PROPOSAL_COMPLEMENT.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa2ff1d44832b8d64dca70e7f6dc4

## Summary by Sourcery

Remove unused backtest variable and expand proposal document with additional feature suggestions

Bug Fixes:
- Remove unused `entry` variable from backtest logic

Documentation:
- Add custom alert sounds, historical market snapshots, and strategy performance rankings proposals to PROPOSAL_COMPLEMENT.md