### PR TITLE
Implement offline cache for DataFetcher

### DIFF
--- a/PROPOSAL_COMPLEMENT.md
+++ b/PROPOSAL_COMPLEMENT.md
@@ -20,3 +20,6 @@ Building upon the existing roadmap, the following additions could further streng
 13. **Cloud Sync for Strategies** – store user strategies in a cloud drive for access across devices.
 14. **Paper Trading Mode** – simulate trades using live data without risking real funds.
 15. **Hardware Wallet Integration** – display balances from Ledger or Trezor devices within the dashboard.
+16. **Smart Notification Filters** – allow users to set conditions that trigger alerts only for high-confidence signals.
+17. **Webhook Extensions** – send real-time trade signals to third-party services via configurable webhooks.
+18. **Custom Report Templates** – let users design summary templates for backtest and portfolio reports.

--- a/tests/test_data_offline.py
+++ b/tests/test_data_offline.py
@@ -1,0 +1,40 @@
+import sys, json
+from pathlib import Path
+import types, importlib
+import pytest
+
+pytest.importorskip("pandas")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_data_fetcher_offline(monkeypatch):
+    class DummyExchange:
+        def fetch_ticker(self, *a, **k):
+            raise AssertionError('network should not be called')
+
+        def fetch_ohlcv(self, *a, **k):
+            raise AssertionError('network should not be called')
+
+    dummy_ccxt = types.ModuleType('ccxt')
+    dummy_ccxt.binance = lambda *a, **k: DummyExchange()
+    monkeypatch.setitem(sys.modules, 'ccxt', dummy_ccxt)
+
+    price_cache = Path('data/price_btcusdt.json')
+    ohlcv_cache = Path('data/ohlcv_btcusdt_1h.json')
+    price_cache.write_text(json.dumps(123.45))
+    ohlcv_cache.write_text(json.dumps([[0, 1, 2, 3, 4, 5]]))
+
+    monkeypatch.setenv('OFFLINE_MODE', '1')
+
+    data_mod = importlib.import_module('trading_bot.data')
+    fetcher = data_mod.DataFetcher('BTC/USDT')
+
+    price = fetcher.get_current_price()
+    df = fetcher.get_ohlcv('1h', limit=1)
+
+    assert price == 123.45
+    assert len(df) == 1
+
+    price_cache.unlink()
+    ohlcv_cache.unlink()

--- a/trading_bot/data.py
+++ b/trading_bot/data.py
@@ -1,6 +1,8 @@
 import ccxt
 import pandas as pd
-from typing import List
+import json
+import os
+from pathlib import Path
 
 class DataFetcher:
     """Fetch market data from Binance via ccxt."""
@@ -9,13 +11,59 @@ class DataFetcher:
         self.exchange = ccxt.binance({"enableRateLimit": True})
 
     def get_current_price(self) -> float:
-        """Return last trade price."""
-        ticker = self.exchange.fetch_ticker(self.symbol)
-        return ticker['last']
+        """Return last trade price with optional offline fallback."""
+        cache_path = (
+            Path(__file__).resolve().parents[1]
+            / "data"
+            / f"price_{self.symbol.replace('/', '').lower()}.json"
+        )
 
-    def get_ohlcv(self, timeframe: str = '1h', limit: int = 500) -> pd.DataFrame:
-        """Return OHLCV data as a DataFrame."""
-        data = self.exchange.fetch_ohlcv(self.symbol, timeframe=timeframe, limit=limit)
-        df = pd.DataFrame(data, columns=['timestamp','open','high','low','close','volume'])
-        df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
-        return df
+        if os.getenv("OFFLINE_MODE") and cache_path.exists():
+            return json.loads(cache_path.read_text())
+
+        try:
+            ticker = self.exchange.fetch_ticker(self.symbol)
+            price = ticker["last"]
+            cache_path.write_text(json.dumps(price))
+            return price
+        except Exception:
+            if cache_path.exists():
+                return json.loads(cache_path.read_text())
+            raise
+
+    def get_ohlcv(self, timeframe: str = "1h", limit: int = 500) -> pd.DataFrame:
+        """Return OHLCV data with optional offline fallback."""
+        cache_path = (
+            Path(__file__).resolve().parents[1]
+            / "data"
+            / f"ohlcv_{self.symbol.replace('/', '').lower()}_{timeframe}.json"
+        )
+
+        if os.getenv("OFFLINE_MODE") and cache_path.exists():
+            cached = json.loads(cache_path.read_text())
+            df = pd.DataFrame(
+                cached, columns=["timestamp", "open", "high", "low", "close", "volume"]
+            )
+            df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+            return df
+
+        try:
+            data = self.exchange.fetch_ohlcv(
+                self.symbol, timeframe=timeframe, limit=limit
+            )
+            df = pd.DataFrame(
+                data, columns=["timestamp", "open", "high", "low", "close", "volume"]
+            )
+            df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+            cache_path.write_text(json.dumps(data))
+            return df
+        except Exception:
+            if cache_path.exists():
+                cached = json.loads(cache_path.read_text())
+                df = pd.DataFrame(
+                    cached,
+                    columns=["timestamp", "open", "high", "low", "close", "volume"],
+                )
+                df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+                return df
+            raise


### PR DESCRIPTION
## Summary
- support offline mode caching in `trading_bot.data`
- test DataFetcher offline behaviour with dummy ccxt
- extend complementary features proposal with more ideas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa2fb2160832b9416e89c82edd260

## Summary by Sourcery

Implement offline cache support for market data fetching, enable fallback on errors, add corresponding offline-mode tests, and enrich proposal document with new ideas.

New Features:
- Add offline caching and fallback for current price and OHLCV data in DataFetcher

Enhancements:
- Use OFFLINE_MODE environment variable to trigger cache-based data retrieval and error fallback

Documentation:
- Extend PROPOSAL_COMPLEMENT.md with additional feature ideas (notification filters, webhooks, report templates)

Tests:
- Add tests for DataFetcher offline behavior using a dummy ccxt exchange and prewritten cache files