### PR TITLE
Add dashboard features and Telegram bot

### DIFF
--- a/crypto_screener_ai/web/dashboard.py
+++ b/crypto_screener_ai/web/dashboard.py
@@ -13,6 +13,8 @@ from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.security.api_key import APIKeyHeader
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+import ccxt
+import plotly.graph_objects as go
 
 from ..app import run_screener, backtest, security_audit
 
@@ -102,11 +104,36 @@ def send_discord(message: str):
         logger.warning('Discord alert failed: %s', exc)
 
 
+def load_webhook_urls() -> list[str]:
+    """Return list of custom webhook URLs from config file."""
+    path = DB_PATH / 'webhooks.json'
+    if not path.exists():
+        return []
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return []
+
+
+def save_webhook_urls(urls: list[str]):
+    (DB_PATH / 'webhooks.json').write_text(json.dumps(urls))
+
+
+def send_custom_webhooks(payload: str):
+    """POST JSON payload to all registered webhook URLs."""
+    for url in load_webhook_urls():
+        try:
+            requests.post(url, data=payload, headers={'Content-Type': 'application/json'}, timeout=10)
+        except Exception as exc:
+            logger.warning('Custom webhook %s failed: %s', url, exc)
+
+
 def notify(message: str):
     send_push(message)
     send_email('CryptoScreenerAI Alert', message)
     send_slack(message)
     send_discord(message)
+    send_custom_webhooks(json.dumps({'message': message}))
 
 
 def get_db():
@@ -130,6 +157,11 @@ def get_db():
                         code TEXT,
                         rating REAL DEFAULT 0,
                         votes INTEGER DEFAULT 0
+                    )''')
+    conn.execute('''CREATE TABLE IF NOT EXISTS strategy_history (
+                        name TEXT,
+                        ts TEXT,
+                        return_pct REAL
                     )''')
     return conn
 
@@ -241,6 +273,19 @@ async def predict(symbol: str):
     return {'symbol': symbol.upper(), 'predicted_change': change}
 
 
+@app.get('/orderbook/{symbol}')
+async def get_orderbook(symbol: str, limit: int = 20):
+    """Return live order book and cache snapshot."""
+    try:
+        ex = ccxt.binance()
+        data = ex.fetch_order_book(symbol, limit=limit)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    cache_file = DB_PATH / f'orderbook_{symbol.replace("/", "")}.json'
+    cache_file.write_text(json.dumps(data))
+    return data
+
+
 @app.get('/portfolio')
 async def get_portfolio(key: str = Depends(require_key)):
     conn = get_db()
@@ -325,6 +370,41 @@ async def portfolio_risk_export(format: str = 'json', key: str = Depends(require
                 yield f"{metrics.get('sharpe_ratio',0)},{metrics.get('max_drawdown',0)}\n"
         return StreamingResponse(generate(), media_type='text/csv')
     return metrics
+
+
+def compute_rebalance(strategy: str = 'equal') -> list[dict]:
+    """Return trade suggestions to rebalance portfolio."""
+    conn = get_db()
+    rows = conn.execute('SELECT symbol, quantity FROM portfolio').fetchall()
+    conn.close()
+    holdings = [{'symbol': r[0], 'quantity': r[1]} for r in rows]
+    if not holdings:
+        return []
+    symbols = ','.join({h['symbol'].lower() for h in holdings})
+    url = f'https://api.coingecko.com/api/v3/simple/price?ids={symbols}&vs_currencies=usd'
+    prices = requests.get(url, timeout=10).json()
+    values = {h['symbol']: h['quantity'] * prices.get(h['symbol'].lower(), {}).get('usd', 0) for h in holdings}
+    total = sum(values.values())
+    if total == 0:
+        return []
+    if strategy != 'equal':
+        raise HTTPException(status_code=400, detail='unsupported strategy')
+    target = total / len(holdings)
+    suggestions = []
+    for h in holdings:
+        current_val = values[h['symbol']]
+        diff = target - current_val
+        if abs(diff) < 1e-8:
+            continue
+        price = prices.get(h['symbol'].lower(), {}).get('usd', 0) or 1
+        qty = diff / price
+        suggestions.append({'symbol': h['symbol'], 'quantity_delta': round(qty, 8)})
+    return suggestions
+
+
+@app.get('/portfolio/rebalance')
+async def portfolio_rebalance(strategy: str = 'equal', key: str = Depends(require_key)):
+    return {'strategy': strategy, 'trades': compute_rebalance(strategy)}
 
 
 @app.get('/strategies')
@@ -429,12 +509,45 @@ async def delete_user(api_key: str, user: dict = Depends(require_admin)):
     return {'status': 'ok'}
 
 
+@app.get('/webhooks')
+async def list_webhooks(user: dict = Depends(require_admin)):
+    """Return registered webhook URLs."""
+    return {'urls': load_webhook_urls()}
+
+
+@app.post('/webhooks')
+async def add_webhook(data: dict, user: dict = Depends(require_admin)):
+    url = data.get('url')
+    if not url:
+        raise HTTPException(status_code=400, detail='url required')
+    urls = load_webhook_urls()
+    if url not in urls:
+        urls.append(url)
+    save_webhook_urls(urls)
+    return {'status': 'ok', 'count': len(urls)}
+
+
+@app.delete('/webhooks')
+async def remove_webhook(data: dict, user: dict = Depends(require_admin)):
+    url = data.get('url')
+    urls = load_webhook_urls()
+    if url in urls:
+        urls.remove(url)
+        save_webhook_urls(urls)
+    return {'status': 'ok', 'count': len(urls)}
+
+
 @app.get('/backtest/{symbol}')
 async def run_backtest_api(symbol: str, days: int = 90, user: dict = Depends(require_admin)):
     try:
         result = backtest.run_backtest(symbol, days)
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
+    conn = get_db()
+    conn.execute('INSERT INTO strategy_history(name, ts, return_pct) VALUES(?,?,?)',
+                 (symbol.upper(), result.get('generated_at'), result.get('return_pct')))
+    conn.commit()
+    conn.close()
     return result
 
 
@@ -483,6 +596,24 @@ async def analytics_report(limit: int = 5, key: str = Depends(require_key)):
         'top_symbols': [
             {'symbol': sym, 'avg_momentum': round(score, 3)} for sym, score in top
         ]
+    }
+
+
+@app.get('/analytics/strategy/{name}')
+async def analytics_strategy(name: str, key: str = Depends(require_key)):
+    """Aggregate historical backtest returns for a strategy."""
+    conn = get_db()
+    rows = conn.execute('SELECT ts, return_pct FROM strategy_history WHERE name=? ORDER BY ts', (name,)).fetchall()
+    conn.close()
+    if not rows:
+        raise HTTPException(status_code=404, detail='Not found')
+    dates = [r[0] for r in rows]
+    returns = [r[1] for r in rows]
+    avg_ret = sum(returns) / len(returns)
+    fig = go.Figure([go.Scatter(x=dates, y=returns, mode='lines')])
+    return {
+        'average_return_pct': avg_ret,
+        'chart_html': fig.to_html(include_plotlyjs=False)
     }
 
 
@@ -556,6 +687,7 @@ def screener_job():
         conn.commit()
         conn.close()
         notify(f"New screener results stored: {js.get('run_id')}")
+        send_custom_webhooks(data)
         if event_loop:
             asyncio.run_coroutine_threadsafe(broadcast_update(data), event_loop)
 

--- a/crypto_screener_ai/web/frontend/index.html
+++ b/crypto_screener_ai/web/frontend/index.html
@@ -32,6 +32,11 @@
       <h2>Analytics</h2>
       <div id="chart" style="width:260px;height:200px;"></div>
     </div>
+    <div class="widget" draggable="true" data-widget="orderbook">
+      <h2>Order Book</h2>
+      <input id="obPair" value="BTC/USDT" /> <button onclick="loadOrderbook()">Load</button>
+      <div id="obChart" style="width:260px;height:200px;"></div>
+    </div>
   </div>
   <script>
     const KEY = 'demo';
@@ -100,11 +105,30 @@
       document.getElementById('answer').textContent = data.response;
     }
 
+    async function loadOrderbook() {
+      const pair = document.getElementById('obPair').value;
+      const resp = await fetch('/orderbook/' + encodeURIComponent(pair));
+      const data = await resp.json();
+      const asks = data.asks.slice(0,20);
+      const bids = data.bids.slice(0,20);
+      function cum(arr){let s=0;return arr.map(v=>s+=v);} 
+      const askPrices = asks.map(a=>a[0]);
+      const bidPrices = bids.map(b=>b[0]);
+      const askQty = cum(asks.map(a=>a[1]));
+      const bidQty = cum(bids.map(b=>b[1]));
+      const traces = [
+        {x: bidPrices, y: bidQty, name:'bids', mode:'lines'},
+        {x: askPrices, y: askQty, name:'asks', mode:'lines'}
+      ];
+      Plotly.newPlot('obChart', traces, {margin:{t:30}});
+    }
+
     loadLayout();
     enableDrag();
     loadLatest();
     loadPnl();
     loadAnalytics();
+    loadOrderbook();
   </script>
 </body>
 </html>

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,0 +1,53 @@
+import os
+import time
+import requests
+
+API_TOKEN = os.getenv('TELEGRAM_TOKEN')
+BASE_URL = f"https://api.telegram.org/bot{API_TOKEN}" if API_TOKEN else None
+
+
+def send_message(chat_id: int, text: str):
+    if not BASE_URL:
+        return
+    try:
+        requests.post(f"{BASE_URL}/sendMessage", data={'chat_id': chat_id, 'text': text}, timeout=10)
+    except Exception:
+        pass
+
+
+def fetch_strategy_summary(name: str) -> str:
+    url = f"http://localhost:9999/strategies/{name}"
+    try:
+        res = requests.get(url, timeout=10)
+        if res.status_code != 200:
+            return "Strategy not found"
+        js = res.json()
+        return (js.get('code', '') or '')[:400]
+    except Exception:
+        return 'Error fetching strategy'
+
+
+def run_bot(poll_interval: int = 5):
+    if not BASE_URL:
+        raise RuntimeError('TELEGRAM_TOKEN not set')
+    offset = 0
+    while True:
+        try:
+            resp = requests.get(f"{BASE_URL}/getUpdates", params={'timeout': 30, 'offset': offset+1}, timeout=35)
+            resp.raise_for_status()
+            data = resp.json().get('result', [])
+            for update in data:
+                offset = update['update_id']
+                msg = update.get('message', {})
+                chat_id = msg.get('chat', {}).get('id')
+                text = msg.get('text', '')
+                if not chat_id or not text:
+                    continue
+                if text.startswith('/strategy '):
+                    name = text.split(' ', 1)[1]
+                    summary = fetch_strategy_summary(name)
+                    send_message(chat_id, summary)
+        except Exception:
+            time.sleep(poll_interval)
+            continue
+        time.sleep(poll_interval)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -57,6 +57,21 @@ def load_dashboard(tmp_path):
     dummy_openai.OpenAI = DummyClient
     sys.modules['openai'] = dummy_openai
 
+    dummy_ccxt = types.ModuleType('ccxt')
+    class DummyExchange:
+        def fetch_order_book(self, symbol, limit=20):
+            return {'bids': [], 'asks': []}
+    dummy_ccxt.binance = lambda *a, **k: DummyExchange()
+    sys.modules['ccxt'] = dummy_ccxt
+
+    dummy_plotly = types.ModuleType('plotly')
+    graph_objs = types.ModuleType('plotly.graph_objects')
+    graph_objs.Figure = lambda *a, **k: types.SimpleNamespace(to_html=lambda **k: '<html>')
+    graph_objs.Scatter = object
+    dummy_plotly.graph_objects = graph_objs
+    sys.modules['plotly'] = dummy_plotly
+    sys.modules['plotly.graph_objects'] = graph_objs
+
     # mock fastapi
     dummy_fastapi = types.ModuleType('fastapi')
     class DummyApp:
@@ -115,7 +130,8 @@ def load_dashboard(tmp_path):
     mod = importlib.import_module('crypto_screener_ai.web.dashboard')
     mod.DB_FILE = Path(tmp_path) / 'test.db'
     # clean up to avoid side effects
-    for name in ['requests', 'dotenv', 'rich', 'openai', 'fastapi', 'fastapi.responses',
+    for name in ['requests', 'dotenv', 'rich', 'openai', 'ccxt', 'plotly', 'plotly.graph_objects',
+                 'fastapi', 'fastapi.responses',
                  'fastapi.security.api_key', 'apscheduler.schedulers.background',
                  'apscheduler.jobstores.sqlalchemy']:
         sys.modules.pop(name, None)

--- a/tests/test_dashboard_new_features.py
+++ b/tests/test_dashboard_new_features.py
@@ -1,0 +1,143 @@
+import sys
+import types
+import importlib
+import json
+from pathlib import Path
+
+class DummyHTTPException(Exception):
+    def __init__(self, status_code=500, detail=None):
+        self.status_code = status_code
+        self.detail = detail
+
+def load_dashboard(tmp_path):
+    # mock requests
+    dummy_requests = types.ModuleType('requests')
+    def post(url, *a, **k):
+        return types.SimpleNamespace(status_code=200)
+    def get(url, *a, **k):
+        if 'coingecko' in url:
+            return types.SimpleNamespace(json=lambda:{'btc':{'usd':100},'eth':{'usd':50}}, status_code=200)
+        return types.SimpleNamespace(json=lambda:{}, status_code=200)
+    dummy_requests.get = get
+    dummy_requests.post = post
+    sys.modules['requests'] = dummy_requests
+
+    # mock ccxt
+    dummy_ccxt = types.ModuleType('ccxt')
+    class DummyExchange:
+        def fetch_order_book(self, symbol, limit=20):
+            return {'bids': [[1,2]], 'asks': [[1.1,3]]}
+    dummy_ccxt.binance = lambda *a, **k: DummyExchange()
+    sys.modules['ccxt'] = dummy_ccxt
+
+    # mock plotly
+    dummy_plotly = types.ModuleType('plotly')
+    graph_objs = types.ModuleType('plotly.graph_objects')
+    class Fig:
+        def __init__(self,*a,**k): pass
+        def to_html(self, **k):
+            return '<html></html>'
+    graph_objs.Figure = lambda *a, **k: Fig()
+    class DummyScatter:
+        def __init__(self, *a, **k):
+            pass
+    graph_objs.Scatter = DummyScatter
+    dummy_plotly.graph_objects = graph_objs
+    sys.modules['plotly'] = dummy_plotly
+    sys.modules['plotly.graph_objects'] = graph_objs
+
+    # fastapi minimal
+    dummy_fastapi = types.ModuleType('fastapi')
+    class DummyApp:
+        def __init__(self,*a,**k): pass
+        def on_event(self,*a,**k):
+            def deco(fn):
+                return fn
+            return deco
+        def get(self,*a,**k):
+            return self.on_event()
+        def post(self,*a,**k):
+            return self.on_event()
+        def delete(self,*a,**k):
+            return self.on_event()
+        def websocket(self,*a,**k):
+            return self.on_event()
+    dummy_fastapi.FastAPI = DummyApp
+    dummy_fastapi.Depends = lambda x:x
+    dummy_fastapi.HTTPException = DummyHTTPException
+    dummy_fastapi.WebSocket = object
+    dummy_fastapi.WebSocketDisconnect = Exception
+    responses_mod = types.ModuleType('fastapi.responses')
+    responses_mod.HTMLResponse = object
+    responses_mod.StreamingResponse = object
+    sys.modules['fastapi.responses'] = responses_mod
+    security_mod = types.ModuleType('fastapi.security.api_key')
+    security_mod.APIKeyHeader = lambda name: None
+    sys.modules['fastapi.security.api_key'] = security_mod
+    dummy_fastapi.responses = responses_mod
+    dummy_fastapi.security = types.SimpleNamespace(api_key=security_mod)
+    sys.modules['fastapi'] = dummy_fastapi
+
+    sched_mod = types.ModuleType('apscheduler.schedulers.background')
+    class DummyScheduler:
+        def __init__(self, *a, **k): pass
+        def add_job(self,*a,**k): pass
+        def start(self): pass
+        def get_job(self,*a,**k): return types.SimpleNamespace(next_run_time=None)
+        def reschedule_job(self,*a,**k): pass
+    sched_mod.BackgroundScheduler = DummyScheduler
+    sys.modules['apscheduler.schedulers.background'] = sched_mod
+    jobstore_mod = types.ModuleType('apscheduler.jobstores.sqlalchemy')
+    jobstore_mod.SQLAlchemyJobStore = lambda url=None: None
+    sys.modules['apscheduler.jobstores.sqlalchemy'] = jobstore_mod
+
+    sys.modules.pop('crypto_screener_ai.web.dashboard', None)
+    mod = importlib.import_module('crypto_screener_ai.web.dashboard')
+    mod.DB_PATH = Path(tmp_path)
+    mod.DB_FILE = mod.DB_PATH / 'db.sqlite'
+    for name in ['requests', 'ccxt', 'plotly', 'plotly.graph_objects', 'fastapi',
+                 'fastapi.responses', 'fastapi.security.api_key',
+                 'apscheduler.schedulers.background', 'apscheduler.jobstores.sqlalchemy']:
+        sys.modules.pop(name, None)
+    return mod
+
+
+def test_orderbook_caching(tmp_path):
+    mod = load_dashboard(tmp_path)
+    import asyncio
+    data = asyncio.run(mod.get_orderbook('BTC/USDT'))
+    cache = Path(mod.DB_PATH) / 'orderbook_BTCUSDT.json'
+    assert cache.exists()
+    assert data['bids']
+
+
+def test_compute_rebalance(tmp_path):
+    mod = load_dashboard(tmp_path)
+    conn = mod.get_db()
+    conn.execute('INSERT INTO portfolio(symbol, quantity) VALUES(?,?)', ('BTC', 1))
+    conn.execute('INSERT INTO portfolio(symbol, quantity) VALUES(?,?)', ('ETH', 1))
+    conn.commit()
+    conn.close()
+    trades = mod.compute_rebalance()
+    assert len(trades) == 2
+
+
+def test_strategy_history(tmp_path):
+    mod = load_dashboard(tmp_path)
+    conn = mod.get_db()
+    conn.execute('INSERT INTO strategy_history(name, ts, return_pct) VALUES (?,?,?)', ('BTC', 't', 5))
+    conn.commit()
+    conn.close()
+    import asyncio
+    resp = asyncio.run(mod.analytics_strategy('BTC'))
+    assert 'average_return_pct' in resp
+
+
+def test_webhook_register(tmp_path):
+    mod = load_dashboard(tmp_path)
+    import asyncio
+    asyncio.run(mod.add_webhook({'url': 'http://example.com'}, user={'role':'admin'}))
+    urls = mod.load_webhook_urls()
+    assert 'http://example.com' in urls
+
+


### PR DESCRIPTION
## Summary
- support order book snapshots and display them in the dashboard
- add portfolio rebalancing calculations
- record strategy history and expose analytics route
- allow custom webhooks for trade signals
- integrate simple Telegram bot module
- add unit tests for new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686013823e20832bb7c35f52d89ee567

## Summary by Sourcery

Add new dashboard endpoints for real-time order book snapshots, portfolio rebalancing, strategy history analytics, and custom webhooks, integrate them into notifications and the front-end, introduce a Telegram bot for strategy queries, and cover these additions with unit tests.

New Features:
- Expose GET /orderbook API to fetch and cache live order book data with front-end visualization
- Provide portfolio rebalancing via GET /portfolio/rebalance endpoint returning trade suggestions
- Record backtest results in a new strategy_history table and expose historical analytics via GET /analytics/strategy/{name}
- Implement custom webhook management endpoints (add/list/remove) and integrate webhook notifications into alerts
- Introduce a Telegram bot module to fetch strategy summaries and send messages

Tests:
- Add unit tests for order book snapshots, portfolio rebalance logic, strategy history analytics, and webhook management