### PR TITLE
Implement pluggable strategies and backtest reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - Added offline mode using cached data when `OFFLINE_MODE` is set.
 - Created community strategy hub with share and rating endpoints.
 - Added CSV/JSON export endpoints for backtests and portfolio risk metrics.
+- Added pluggable strategy loader and HTML report generation for backtests.
+- Improved top volume fetcher with caching fallback for offline mode.
 
 ## [0.1.0] - 2024-03-01
 - Initial release with CLI screener and dashboard.

--- a/PROPOSAL_EXTRA_FEATURES.md
+++ b/PROPOSAL_EXTRA_FEATURES.md
@@ -6,5 +6,6 @@ To further enhance the Alerts Bot and CryptoScreenerAI ecosystem, consider the f
 2. **Price Anomaly Detector** – highlight sudden price spikes or drops across watchlisted assets using statistical outlier detection.
 3. **Webhook Trigger Rules** – let users define custom conditions (e.g., RSI crossing thresholds) that send a webhook notification or execute a script when met.
 4. **Custom Report Scheduler** – generate PDF or HTML summaries of backtest results and portfolio metrics on a weekly or monthly cadence.
+5. **Strategy Template Loader** – allow users to drop Python files into the `strategies` folder and select them via the API for backtests.
 
 These additions would complement existing analytics and alerting functionality, providing more automation and actionable insights.

--- a/PROPOSAL_NEW_FEATURES.md
+++ b/PROPOSAL_NEW_FEATURES.md
@@ -13,3 +13,4 @@ These additions would expand usability across different regions and devices whil
 4. **Automated Security Audits** – run static analysis on strategy code and dependencies before deployment.
 5. **Offline Mode** – allow limited analysis using cached data when network connectivity is interrupted.
 6. **Community Strategy Hub** – share and rate user-submitted strategies directly from the dashboard.
+7. **Pluggable Strategy Engine** – load strategy classes dynamically so traders can experiment without modifying core code.

--- a/README.md
+++ b/README.md
@@ -176,5 +176,7 @@ results are stored:
 - **Offline Mode**: set `OFFLINE_MODE=1` to use cached data when the network is unavailable.
 - **Community Strategy Hub**: share and rate strategies via `/community/strategies`.
 - **Data Export Tools**: `/backtest/{symbol}/export` and `/portfolio/risk/export` provide CSV or JSON downloads.
+- **Pluggable Strategies**: drop custom modules into `strategies/` and select via the backtest API.
+- **Backtest Reports**: `run_backtest` now returns Plotly HTML charts for quick visual analysis.
 
 See CHANGELOG.md for release history and PROPOSAL_NEW_FEATURES.md for upcoming ideas.

--- a/crypto_screener_ai/app/backtest.py
+++ b/crypto_screener_ai/app/backtest.py
@@ -1,9 +1,11 @@
-import datetime
 import json
 import os
 import requests
-from typing import List, Dict
+from typing import List, Dict, Callable
 from pathlib import Path
+import importlib.util
+import datetime
+import plotly.graph_objects as go
 
 
 def fetch_historical_prices(symbol: str, days: int = 90) -> List[float]:
@@ -38,8 +40,8 @@ def simple_moving_average_cross(prices: List[float], short: int = 5, long: int =
     entry_price = 0.0
     balance = 1.0
     for i in range(long, len(prices)):
-        short_ma = sum(prices[i-short:i]) / short
-        long_ma = sum(prices[i-long:i]) / long
+        short_ma = sum(prices[i - short : i]) / short
+        long_ma = sum(prices[i - long : i]) / long
         price = prices[i]
         if not position and short_ma > long_ma:
             position = True
@@ -49,15 +51,44 @@ def simple_moving_average_cross(prices: List[float], short: int = 5, long: int =
             balance *= price / entry_price
     if position:
         balance *= prices[-1] / entry_price
-    return {"trades": 1 if balance != 1.0 else 0, "return_pct": round((balance-1)*100, 2)}
+    return {
+        "trades": 1 if balance != 1.0 else 0,
+        "return_pct": round((balance - 1) * 100, 2),
+    }
 
 
-def run_backtest(symbol: str, days: int = 90) -> Dict[str, float]:
+def load_strategy(name: str) -> Callable[[List[float]], Dict[str, float]]:
+    """Dynamically load a strategy by name from the strategies folder."""
+    strategy_dir = Path(__file__).resolve().parents[2] / "strategies"
+    path = strategy_dir / f"{name}.py"
+    if not path.exists():
+        raise ValueError("Strategy not found")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(module)
+    if hasattr(module, "Strategy"):
+        strat_cls = getattr(module, "Strategy")
+        strat = strat_cls()
+        return strat.run
+    if hasattr(module, "backtest"):
+        return getattr(module, "backtest")
+    raise ValueError("No Strategy or backtest callable in module")
+
+
+def run_backtest(symbol: str, days: int = 90, strategy: str = "sma_cross") -> Dict[str, float]:
     prices = fetch_historical_prices(symbol, days)
     if not prices:
         raise ValueError("No data returned")
-    result = simple_moving_average_cross(prices)
+    try:
+        strat_fn = load_strategy(strategy)
+    except Exception:
+        strat_fn = simple_moving_average_cross
+    result = strat_fn(prices)
     result["symbol"] = symbol.upper()
     result["period_days"] = days
     result["generated_at"] = datetime.datetime.utcnow().isoformat() + "Z"
+    # generate simple performance plot
+    fig = go.Figure([go.Scatter(y=prices, mode="lines")])
+    result["chart_html"] = fig.to_html(include_plotlyjs=False)
     return result

--- a/crypto_screener_ai/app/run_screener.py
+++ b/crypto_screener_ai/app/run_screener.py
@@ -7,16 +7,7 @@ New features:
   • Automatically appends top-25-by-volume (CoinGecko) to the watch-list
   • Adds Task 8 asking for five best ideas in next 30 min
 """
-import argparse
-import datetime
-import json
-import os
-import uuid
-import requests
-
-import requests
-import uuid
- 
+import json, os, uuid, datetime, argparse, requests
 from pathlib import Path
 from dotenv import load_dotenv
 from rich import print
@@ -24,9 +15,10 @@ from openai import OpenAI
 
 # ---------- helpers -----------------------------------------------------------
 def fetch_top_25_volume(vs_currency: str = "usd") -> list[str]:
-    cache_file = Path(__file__).resolve().parents[2] / "data" / "top25_cache.json"
-    if os.getenv("OFFLINE_MODE"):
-        return json.loads(cache_file.read_text())
+    """Return top traded symbols with cache fallback."""
+    cache_path = Path(__file__).resolve().parents[2] / "data" / "top25_cache.json"
+    if os.getenv("OFFLINE_MODE") and cache_path.exists():
+        return json.loads(cache_path.read_text())
 
     url = (
         "https://api.coingecko.com/api/v3/coins/markets"
@@ -35,13 +27,16 @@ def fetch_top_25_volume(vs_currency: str = "usd") -> list[str]:
     try:
         res = requests.get(url, timeout=10)
         res.raise_for_status()
-        return [coin["symbol"].upper() for coin in res.json()]
+        symbols = [coin["symbol"].upper() for coin in res.json()]
+        cache_path.write_text(json.dumps(symbols))
+        return symbols
     except Exception as exc:
         print(
-            f"[yellow]⚠️  Could not fetch top-25 volume list ({exc}); "
-            "continuing with defaults.[/]"
+            f"[yellow]⚠️  Could not fetch top-25 volume list ({exc}); continuing with defaults.[/]"
         )
-        return json.loads(cache_file.read_text())
+        if cache_path.exists():
+            return json.loads(cache_path.read_text())
+        return []
 
 # ---------- main --------------------------------------------------------------
 def main():

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,0 +1,4 @@
+class Strategy:
+    """Abstract strategy interface."""
+    def run(self, prices):
+        raise NotImplementedError

--- a/strategies/sma_cross.py
+++ b/strategies/sma_cross.py
@@ -1,19 +1,38 @@
 """Simple moving-average cross strategy."""
 
+from .base import Strategy
+
+
+class SMACrossStrategy(Strategy):
+    """Moving average cross implemented as a pluggable Strategy."""
+
+    def __init__(self, short: int = 5, long: int = 20):
+        self.short = short
+        self.long = long
+
+    def run(self, prices):
+        position = False
+        entry = 0
+        balance = 1.0
+        for i in range(self.long, len(prices)):
+            short_ma = sum(prices[i - self.short : i]) / self.short
+            long_ma = sum(prices[i - self.long : i]) / self.long
+            price = prices[i]
+            if not position and short_ma > long_ma:
+                position = True
+                entry = price
+            elif position and short_ma < long_ma:
+                balance *= price / entry
+                position = False
+        if position:
+            balance *= prices[-1] / entry
+        return balance - 1
+
+
 def backtest(prices, short=5, long=20):
-    position = False
-    entry = 0
-    balance = 1.0
-    for i in range(long, len(prices)):
-        short_ma = sum(prices[i-short:i])/short
-        long_ma = sum(prices[i-long:i])/long
-        price = prices[i]
-        if not position and short_ma > long_ma:
-            position = True
-            entry = price
-        elif position and short_ma < long_ma:
-            balance *= price/entry
-            position = False
-    if position:
-        balance *= prices[-1]/entry
-    return balance-1
+    """Backward compatible functional API."""
+    strat = SMACrossStrategy(short=short, long=long)
+    return strat.run(prices)
+
+# Allow dynamic loaders to reference `Strategy` generically
+Strategy = SMACrossStrategy

--- a/tests/test_backtest_offline.py
+++ b/tests/test_backtest_offline.py
@@ -18,6 +18,14 @@ def test_fetch_historical_prices_offline(tmp_path, monkeypatch):
     dummy_requests.get = get
     monkeypatch.setitem(sys.modules, 'requests', dummy_requests)
 
+    dummy_plotly = types.ModuleType('plotly')
+    graph_objs = types.ModuleType('plotly.graph_objects')
+    graph_objs.Figure = lambda *a, **k: types.SimpleNamespace(to_html=lambda **kw: '<html>')
+    graph_objs.Scatter = lambda *a, **k: object()
+    dummy_plotly.graph_objects = graph_objs
+    monkeypatch.setitem(sys.modules, 'plotly', dummy_plotly)
+    monkeypatch.setitem(sys.modules, 'plotly.graph_objects', graph_objs)
+
     cache = Path('data/hist_btc.json')
     cache.write_text(json.dumps([1, 2, 3]))
     monkeypatch.setenv('OFFLINE_MODE', '1')

--- a/tests/test_strategy_pluggable.py
+++ b/tests/test_strategy_pluggable.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_load_strategy(tmp_path):
+    dummy_requests = types.ModuleType('requests')
+    dummy_requests.get = lambda *a, **k: types.SimpleNamespace(json=lambda: {'prices': [[0,1],[1,2],[2,3]]}, raise_for_status=lambda: None)
+    sys.modules['requests'] = dummy_requests
+
+    dummy_plotly = types.ModuleType('plotly')
+    graph_objs = types.ModuleType('plotly.graph_objects')
+    graph_objs.Figure = lambda *a, **k: types.SimpleNamespace(to_html=lambda **kw: '<html>')
+    graph_objs.Scatter = lambda *a, **k: object()
+    dummy_plotly.graph_objects = graph_objs
+    sys.modules['plotly'] = dummy_plotly
+    sys.modules['plotly.graph_objects'] = graph_objs
+
+    sys.modules.pop('crypto_screener_ai.app.backtest', None)
+    mod = importlib.import_module('crypto_screener_ai.app.backtest')
+    # create dummy strategy file
+    strat_file = tmp_path / 'dummy.py'
+    strat_file.write_text('''class Strategy:\n    def run(self, prices):\n        return {"trades": 0, "return_pct": 1.23}''')
+    # temporarily add to strategies path
+    orig = Path(mod.__file__).resolve().parents[2] / 'strategies'
+    orig.mkdir(exist_ok=True)
+    target = orig / 'dummy.py'
+    target.write_text(strat_file.read_text())
+    try:
+        result = mod.run_backtest('btc', days=1, strategy='dummy')
+        assert result['return_pct'] == 1.23
+        assert 'chart_html' in result
+    finally:
+        target.unlink()
+


### PR DESCRIPTION
## Summary
- add Strategy base class and convert `sma_cross` to use it
- implement dynamic strategy loader and HTML report generation in backtester
- cache fallback for top-volume fetcher
- document new features in README and proposals
- extend changelog
- add unit tests for new strategy loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686031724c58832bb8cb1b65809b5d72

## Summary by Sourcery

Enable pluggable trading strategies by adding a Strategy base class, dynamic loader, and extending the backtest API to select and run custom modules. Enhance backtester to generate Plotly HTML performance charts, improve top-volume fetcher with caching fallback in offline mode, and update documentation, changelog, and unit tests for the new features.

New Features:
- Introduce a Strategy base class and convert the existing SMA cross to use it as a plugin
- Implement a dynamic strategy loader and allow run_backtest to select strategies by name with fallback to default
- Generate interactive HTML charts (via Plotly) in backtest results
- Enhance fetch_top_25_volume to cache fetched symbols and support offline-mode fallback

Documentation:
- Document pluggable strategies and backtest report features in README and proposal files
- Update CHANGELOG.md to record the new strategy loader, HTML reporting, and caching enhancements

Tests:
- Add unit tests for the pluggable strategy loader and offline backtest mode with mocked Plotly integration