### PR TITLE
Update SMA cross outputs and add default backtest test

### DIFF
--- a/PROPOSAL_COMPLEMENT.md
+++ b/PROPOSAL_COMPLEMENT.md
@@ -26,3 +26,6 @@ Building upon the existing roadmap, the following additions could further streng
 16. **Realtime Risk Alerts** – monitor volatility spikes and auto-adjust leverage suggestions.
 17. **Portfolio Heatmap** – visualize asset allocation and performance with Plotly.
 18. **Cloud-based Backtesting Farm** – distribute heavy computations across remote workers.
+19. **ML Signal Ranking** – score trade setups with a lightweight machine-learning model for prioritisation.
+20. **Cloud Data Pipeline** – stream market data to a managed timeseries database for faster queries.
+21. **Collaborative Workspaces** – share dashboards and backtest results with teammates in real time.

--- a/strategies/sma_cross.py
+++ b/strategies/sma_cross.py
@@ -11,9 +11,11 @@ class SMACrossStrategy(Strategy):
         self.long = long
 
     def run(self, prices):
+        """Execute the SMA cross strategy and return trade stats."""
         position = False
-        entry = 0
+        entry = 0.0
         balance = 1.0
+        trades = 0
         for i in range(self.long, len(prices)):
             short_ma = sum(prices[i - self.short : i]) / self.short
             long_ma = sum(prices[i - self.long : i]) / self.long
@@ -21,16 +23,20 @@ class SMACrossStrategy(Strategy):
             if not position and short_ma > long_ma:
                 position = True
                 entry = price
+                trades += 1
             elif position and short_ma < long_ma:
                 balance *= price / entry
                 position = False
         if position:
             balance *= prices[-1] / entry
-        return balance - 1
+        return {
+            "trades": trades,
+            "return_pct": round((balance - 1) * 100, 2),
+        }
 
 
 def backtest(prices, short=5, long=20):
-    """Backward compatible functional API."""
+    """Backward compatible functional API returning trade stats."""
     strat = SMACrossStrategy(short=short, long=long)
     return strat.run(prices)
 

--- a/tests/test_backtest_default.py
+++ b/tests/test_backtest_default.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_run_backtest_default(monkeypatch):
+    dummy_requests = types.ModuleType('requests')
+    dummy_requests.get = lambda *a, **k: types.SimpleNamespace(json=lambda: {'prices': [[0,1],[1,2]]}, raise_for_status=lambda: None)
+    monkeypatch.setitem(sys.modules, 'requests', dummy_requests)
+
+    dummy_plotly = types.ModuleType('plotly')
+    graph_objs = types.ModuleType('plotly.graph_objects')
+    graph_objs.Figure = lambda *a, **k: types.SimpleNamespace(to_html=lambda **kw: '<html>')
+    graph_objs.Scatter = lambda *a, **k: object()
+    dummy_plotly.graph_objects = graph_objs
+    monkeypatch.setitem(sys.modules, 'plotly', dummy_plotly)
+    monkeypatch.setitem(sys.modules, 'plotly.graph_objects', graph_objs)
+
+    sys.modules.pop('crypto_screener_ai.app.backtest', None)
+    backtest = importlib.import_module('crypto_screener_ai.app.backtest')
+
+    monkeypatch.setattr(backtest, 'fetch_historical_prices', lambda symbol, days=90: [1,2,3,4,5])
+
+    result = backtest.run_backtest('btc')
+    assert result['symbol'] == 'BTC'
+    assert 'chart_html' in result
+    assert 'return_pct' in result


### PR DESCRIPTION
## Summary
- update SMA cross strategy to return trade stats
- create a test for running the default backtest
- append a few feature ideas to proposal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603408f74c832b969f362fe64c565a

## Summary by Sourcery

Enhance the SMA cross strategy to output comprehensive trade stats, update the backtest API accordingly, add a default backtest test, and enrich the project proposal with additional feature suggestions.

New Features:
- Return detailed trade statistics (number of trades and return percentage) from the SMA cross strategy and backward-compatible backtest API.

Documentation:
- Expand PROPOSAL_COMPLEMENT.md with three new feature ideas for ML signal ranking, cloud data pipeline, and collaborative workspaces.

Tests:
- Add an integration-style test for the default backtest flow using mocked requests and Plotly modules.