### PR TITLE
Add API monitoring metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Added CSV/JSON export endpoints for backtests and portfolio risk metrics.
 - Added pluggable strategy loader and HTML report generation for backtests.
 - Improved top volume fetcher with caching fallback for offline mode.
+- Added API monitoring with `/metrics` endpoint and helper to track upstream usage.
 
 ## [0.1.0] - 2024-03-01
 - Initial release with CLI screener and dashboard.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ results are stored:
 - `SLACK_WEBHOOK_URL` to post alerts to a Slack channel
 - `DISCORD_WEBHOOK_URL` to send alerts to Discord
 
+The dashboard tracks usage of external APIs. Visit `/metrics` to view request
+counts, failures and total duration per provider.
+
 ## New Features
 - **Real-Time WebSockets**: Subscribe to `/ws/results` for instant screener updates.
 - **Advanced Backtesting**: `/backtest/{symbol}` endpoint simulates strategies using historical prices.
@@ -178,5 +181,6 @@ results are stored:
 - **Data Export Tools**: `/backtest/{symbol}/export` and `/portfolio/risk/export` provide CSV or JSON downloads.
 - **Pluggable Strategies**: drop custom modules into `strategies/` and select via the backtest API.
 - **Backtest Reports**: `run_backtest` now returns Plotly HTML charts for quick visual analysis.
+- **API Monitoring**: `/metrics` displays call counts and latency for upstream services.
 
 See CHANGELOG.md for release history and PROPOSAL_NEW_FEATURES.md for upcoming ideas.

--- a/crypto_screener_ai/app/backtest.py
+++ b/crypto_screener_ai/app/backtest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import requests
+from .monitoring import record_api_call
 from typing import List, Dict, Callable
 from pathlib import Path
 import importlib.util
@@ -20,7 +21,7 @@ def fetch_historical_prices(symbol: str, days: int = 90) -> List[float]:
         f"?vs_currency=usd&days={days}&interval=daily"
     )
     try:
-        res = requests.get(url, timeout=10)
+        res = record_api_call("coingecko", requests.get, url, timeout=10)
         res.raise_for_status()
         data = res.json().get("prices", [])
         prices = [p[1] for p in data]

--- a/crypto_screener_ai/app/monitoring.py
+++ b/crypto_screener_ai/app/monitoring.py
@@ -1,0 +1,23 @@
+import time
+from collections import defaultdict
+from typing import Callable, Any
+
+# service -> {count, failures, duration}
+API_METRICS: dict[str, dict[str, float]] = defaultdict(lambda: {
+    "count": 0,
+    "failures": 0,
+    "duration": 0.0,
+})
+
+
+def record_api_call(service: str, func: Callable[..., Any], *args, **kwargs) -> Any:
+    """Execute func while recording metrics for the given service."""
+    start = time.perf_counter()
+    try:
+        return func(*args, **kwargs)
+    except Exception:
+        API_METRICS[service]["failures"] += 1
+        raise
+    finally:
+        API_METRICS[service]["count"] += 1
+        API_METRICS[service]["duration"] += time.perf_counter() - start

--- a/crypto_screener_ai/app/run_screener.py
+++ b/crypto_screener_ai/app/run_screener.py
@@ -8,6 +8,7 @@ New features:
   • Adds Task 8 asking for five best ideas in next 30 min
 """
 import json, os, uuid, datetime, argparse, requests
+from .monitoring import record_api_call
 from pathlib import Path
 from dotenv import load_dotenv
 from rich import print
@@ -25,7 +26,7 @@ def fetch_top_25_volume(vs_currency: str = "usd") -> list[str]:
         f"?vs_currency={vs_currency}&order=volume_desc&per_page=25&page=1"
     )
     try:
-        res = requests.get(url, timeout=10)
+        res = record_api_call("coingecko", requests.get, url, timeout=10)
         res.raise_for_status()
         symbols = [coin["symbol"].upper() for coin in res.json()]
         cache_path.write_text(json.dumps(symbols))

--- a/crypto_screener_ai/web/dashboard.py
+++ b/crypto_screener_ai/web/dashboard.py
@@ -9,7 +9,7 @@ from email.message import EmailMessage
 import requests
 from pathlib import Path
 from fastapi import FastAPI, Depends, HTTPException, WebSocket, WebSocketDisconnect
-from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, StreamingResponse, JSONResponse
 from fastapi.security.api_key import APIKeyHeader
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
@@ -17,6 +17,7 @@ import ccxt
 import plotly.graph_objects as go
 
 from ..app import run_screener, backtest, security_audit
+from ..app.monitoring import record_api_call, API_METRICS
 
 DB_PATH = Path(__file__).resolve().parents[1] / 'data'
 DB_PATH.mkdir(exist_ok=True)
@@ -29,6 +30,13 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(mess
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title='CryptoScreenerAI Dashboard')
+
+# expose metrics via middleware
+@app.middleware('http')
+async def metrics_endpoint(request, call_next):
+    if request.url.path == '/metrics':
+        return JSONResponse(API_METRICS)
+    return await call_next(request)
 
 SENTIMENT_DATA = {'sentiment': 'neutral', 'score': 0.0}
 SOCIAL_POSTS: list[str] = []
@@ -330,7 +338,7 @@ async def portfolio_pnl(key: str = Depends(require_key)):
     if not symbols:
         return []
     url = f'https://api.coingecko.com/api/v3/simple/price?ids={symbols}&vs_currencies=usd'
-    res = requests.get(url, timeout=10)
+    res = record_api_call('coingecko', requests.get, url, timeout=10)
     res.raise_for_status()
     prices = res.json()
     results = []
@@ -382,7 +390,7 @@ def compute_rebalance(strategy: str = 'equal') -> list[dict]:
         return []
     symbols = ','.join({h['symbol'].lower() for h in holdings})
     url = f'https://api.coingecko.com/api/v3/simple/price?ids={symbols}&vs_currencies=usd'
-    prices = requests.get(url, timeout=10).json()
+    prices = record_api_call('coingecko', requests.get, url, timeout=10).json()
     values = {h['symbol']: h['quantity'] * prices.get(h['symbol'].lower(), {}).get('usd', 0) for h in holdings}
     total = sum(values.values())
     if total == 0:
@@ -703,7 +711,7 @@ def fetch_social_posts():
     global SOCIAL_POSTS
     url = 'https://www.reddit.com/r/CryptoCurrency/top.json?limit=5&t=day'
     try:
-        res = requests.get(url, headers={'User-Agent': 'CryptoScreenerAI'}, timeout=10)
+        res = record_api_call('reddit', requests.get, url, headers={'User-Agent': 'CryptoScreenerAI'}, timeout=10)
         res.raise_for_status()
         data = res.json()
         SOCIAL_POSTS = [child['data']['title'] for child in data['data']['children']]

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -81,6 +81,8 @@ def load_dashboard(tmp_path):
             def deco(fn):
                 return fn
             return deco
+        def middleware(self,*a,**k):
+            return self.on_event()
         def get(self, *a, **k):
             return self.on_event()
         def post(self, *a, **k):
@@ -97,6 +99,7 @@ def load_dashboard(tmp_path):
     responses_mod = types.ModuleType('fastapi.responses')
     responses_mod.HTMLResponse = object
     responses_mod.StreamingResponse = object
+    responses_mod.JSONResponse = object
     sys.modules['fastapi.responses'] = responses_mod
     security_mod = types.ModuleType('fastapi.security.api_key')
     security_mod.APIKeyHeader = lambda name: None

--- a/tests/test_dashboard_new_features.py
+++ b/tests/test_dashboard_new_features.py
@@ -54,6 +54,8 @@ def load_dashboard(tmp_path):
             def deco(fn):
                 return fn
             return deco
+        def middleware(self,*a,**k):
+            return self.on_event()
         def get(self,*a,**k):
             return self.on_event()
         def post(self,*a,**k):
@@ -70,6 +72,7 @@ def load_dashboard(tmp_path):
     responses_mod = types.ModuleType('fastapi.responses')
     responses_mod.HTMLResponse = object
     responses_mod.StreamingResponse = object
+    responses_mod.JSONResponse = object
     sys.modules['fastapi.responses'] = responses_mod
     security_mod = types.ModuleType('fastapi.security.api_key')
     security_mod.APIKeyHeader = lambda name: None

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,50 @@
+import types
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip('pandas')
+
+
+def test_api_metrics(monkeypatch, tmp_path):
+    monitoring = importlib.import_module('crypto_screener_ai.app.monitoring')
+    monitoring.API_METRICS.clear()
+
+    # mock requests.get for backtest
+    dummy_requests = types.ModuleType('requests')
+    dummy_requests.get = lambda *a, **k: types.SimpleNamespace(json=lambda:{'prices': [[0, 1]]}, raise_for_status=lambda: None)
+    monkeypatch.setitem(sys.modules, 'requests', dummy_requests)
+    dummy_plotly = types.ModuleType('plotly')
+    graph_objs = types.ModuleType('plotly.graph_objects')
+    graph_objs.Figure = lambda *a, **k: types.SimpleNamespace(to_html=lambda **kw: '<html>')
+    graph_objs.Scatter = object
+    monkeypatch.setitem(sys.modules, 'plotly', dummy_plotly)
+    monkeypatch.setitem(sys.modules, 'plotly.graph_objects', graph_objs)
+    sys.modules.pop('crypto_screener_ai.app.backtest', None)
+    backtest = importlib.import_module('crypto_screener_ai.app.backtest')
+    prices = backtest.fetch_historical_prices('btc', days=1)
+    assert prices == [1]
+    assert monitoring.API_METRICS['coingecko']['count'] == 1
+    assert monitoring.API_METRICS['coingecko']['failures'] == 0
+    assert monitoring.API_METRICS['coingecko']['duration'] > 0
+
+    monitoring.API_METRICS.clear()
+
+    # mock ccxt for DataFetcher
+    dummy_ccxt = types.ModuleType('ccxt')
+    class DummyEx:
+        def fetch_ticker(self, symbol):
+            return {'last': 10}
+    dummy_ccxt.binance = lambda *a, **k: DummyEx()
+    monkeypatch.setitem(sys.modules, 'ccxt', dummy_ccxt)
+    sys.modules.pop('trading_bot.data', None)
+    from trading_bot.data import DataFetcher
+    fetcher = DataFetcher('BTC/USDT')
+    price = fetcher.get_current_price()
+    assert price == 10
+    assert monitoring.API_METRICS['binance']['count'] == 1
+    assert monitoring.API_METRICS['binance']['failures'] == 0
+    assert monitoring.API_METRICS['binance']['duration'] > 0
+

--- a/trading_bot/data.py
+++ b/trading_bot/data.py
@@ -6,6 +6,7 @@ import pandas as pd
 import json
 import os
 from pathlib import Path
+from crypto_screener_ai.app.monitoring import record_api_call
 
 
 class DataFetcher:
@@ -39,7 +40,7 @@ class DataFetcher:
             return json.loads(cache_path.read_text())
 
         try:
-            ticker = self.exchange.fetch_ticker(self.symbol)
+            ticker = record_api_call("binance", self.exchange.fetch_ticker, self.symbol)
             price = ticker["last"]
             cache_path.write_text(json.dumps(price))
             return price
@@ -65,8 +66,12 @@ class DataFetcher:
             return df
 
         try:
-            data = self.exchange.fetch_ohlcv(
-                self.symbol, timeframe=timeframe, limit=limit
+            data = record_api_call(
+                "binance",
+                self.exchange.fetch_ohlcv,
+                self.symbol,
+                timeframe=timeframe,
+                limit=limit,
             )
             df = pd.DataFrame(
                 data, columns=["timestamp", "open", "high", "low", "close", "volume"]


### PR DESCRIPTION
## Summary
- monitor upstream API calls in new monitoring module
- wrap requests to CoinGecko, Binance and Reddit with `record_api_call`
- expose `/metrics` via FastAPI middleware
- test metrics collection with mocked requests and ccxt
- document API monitoring in README and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603628fcc0832ba9a5772eae879d06

## Summary by Sourcery

Add end-to-end external API monitoring by instrumenting service calls, exposing a metrics endpoint, and updating documentation and tests.

New Features:
- Introduce record_api_call helper and API_METRICS store to track external API usage.
- Wrap CoinGecko, Binance (ccxt) and Reddit calls with metrics recording.
- Expose aggregated API metrics at /metrics via FastAPI middleware.

Documentation:
- Document API monitoring and /metrics endpoint in README and CHANGELOG.

Tests:
- Add tests to verify API metrics recording and update dashboard tests to support the metrics middleware.