### PR TITLE
Add trading commands and backtesting to telegram bot

### DIFF
--- a/crypto_screener_ai/app/run_screener.py
+++ b/crypto_screener_ai/app/run_screener.py
@@ -15,10 +15,12 @@ from openai import OpenAI
 
 # ---------- helpers -----------------------------------------------------------
 def fetch_top_25_volume(vs_currency: str = "usd") -> list[str]:
-    """Return top traded symbols with cache fallback."""
-    cache_path = Path(__file__).resolve().parents[2] / "data" / "top25_cache.json"
-    if os.getenv("OFFLINE_MODE") and cache_path.exists():
-        return json.loads(cache_path.read_text())
+    cache = Path(__file__).resolve().parents[2] / "data" / "top25_cache.json"
+    if os.getenv("OFFLINE_MODE") and cache.exists():
+        try:
+            return json.loads(cache.read_text())
+        except Exception:
+            return []
 
     url = (
         "https://api.coingecko.com/api/v3/coins/markets"
@@ -27,15 +29,15 @@ def fetch_top_25_volume(vs_currency: str = "usd") -> list[str]:
     try:
         res = requests.get(url, timeout=10)
         res.raise_for_status()
-        symbols = [coin["symbol"].upper() for coin in res.json()]
-        cache_path.write_text(json.dumps(symbols))
-        return symbols
+        return [coin["symbol"].upper() for coin in res.json()]
     except Exception as exc:
-        print(
-            f"[yellow]⚠️  Could not fetch top-25 volume list ({exc}); continuing with defaults.[/]"
-        )
-        if cache_path.exists():
-            return json.loads(cache_path.read_text())
+        print(f"[yellow]⚠️  Could not fetch top-25 volume list ({exc}); "
+              "continuing with defaults.[/]")
+        if cache.exists():
+            try:
+                return json.loads(cache.read_text())
+            except Exception:
+                return []
         return []
 
 # ---------- main --------------------------------------------------------------

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,9 +1,16 @@
 import os
 import time
+import json
+from pathlib import Path
 import requests
+from typing import Dict
+
+from crypto_screener_ai.app.backtest import run_backtest
 
 API_TOKEN = os.getenv('TELEGRAM_TOKEN')
 BASE_URL = f"https://api.telegram.org/bot{API_TOKEN}" if API_TOKEN else None
+ALLOWED_IDS = [int(x) for x in os.getenv("TELEGRAM_ALLOWED_IDS", "").split(",") if x.strip()]
+PORTFOLIO_PATH = Path("data/telegram_portfolio.json")
 
 
 def send_message(chat_id: int, text: str):
@@ -27,6 +34,28 @@ def fetch_strategy_summary(name: str) -> str:
         return 'Error fetching strategy'
 
 
+def load_portfolio() -> Dict[str, float]:
+    if PORTFOLIO_PATH.exists():
+        try:
+            return json.loads(PORTFOLIO_PATH.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def save_portfolio(data: Dict[str, float]):
+    PORTFOLIO_PATH.write_text(json.dumps(data))
+
+
+def update_portfolio(symbol: str, qty: float):
+    port = load_portfolio()
+    sym = symbol.upper()
+    port[sym] = port.get(sym, 0) + qty
+    if abs(port[sym]) < 1e-8:
+        port.pop(sym)
+    save_portfolio(port)
+
+
 def run_bot(poll_interval: int = 5):
     if not BASE_URL:
         raise RuntimeError('TELEGRAM_TOKEN not set')
@@ -38,16 +67,52 @@ def run_bot(poll_interval: int = 5):
             data = resp.json().get('result', [])
             for update in data:
                 offset = update['update_id']
-                msg = update.get('message', {})
-                chat_id = msg.get('chat', {}).get('id')
-                text = msg.get('text', '')
-                if not chat_id or not text:
-                    continue
-                if text.startswith('/strategy '):
-                    name = text.split(' ', 1)[1]
-                    summary = fetch_strategy_summary(name)
-                    send_message(chat_id, summary)
+                process_update(update)
         except Exception:
             time.sleep(poll_interval)
             continue
         time.sleep(poll_interval)
+
+
+def process_update(update: Dict):
+    msg = update.get('message', {})
+    chat_id = msg.get('chat', {}).get('id')
+    text = msg.get('text', '')
+    if not chat_id or not text:
+        return
+
+    if text.startswith('/strategy '):
+        name = text.split(' ', 1)[1]
+        summary = fetch_strategy_summary(name)
+        send_message(chat_id, summary)
+        return
+
+    if text.startswith('/backtest '):
+        symbol = text.split(' ', 1)[1].strip()
+        try:
+            result = run_backtest(symbol)
+            reply = f"Return: {result.get('return_pct', 0)}%"
+        except Exception as exc:
+            reply = f"Error: {exc}"
+        send_message(chat_id, reply)
+        return
+
+    if text.startswith('/buy ') or text.startswith('/sell '):
+        if chat_id not in ALLOWED_IDS:
+            send_message(chat_id, 'Not authorized')
+            return
+        parts = text.split()
+        if len(parts) != 3:
+            send_message(chat_id, 'Usage: /buy SYMBOL QTY')
+            return
+        symbol = parts[1]
+        try:
+            qty = float(parts[2])
+        except ValueError:
+            send_message(chat_id, 'Invalid quantity')
+            return
+        if text.startswith('/sell'):
+            qty = -qty
+        update_portfolio(symbol, qty)
+        send_message(chat_id, 'Order executed')
+

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1,0 +1,56 @@
+import importlib
+import types
+import sys
+import json
+from pathlib import Path
+
+import pytest
+
+
+def load_bot(tmp_path, monkeypatch, allowed='1'):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    monkeypatch.setenv('TELEGRAM_ALLOWED_IDS', allowed)
+    monkeypatch.setenv('TELEGRAM_TOKEN', 'x')
+    messages = []
+
+    dummy_requests = types.ModuleType('requests')
+    def post(url, data=None, timeout=10):
+        messages.append((data['chat_id'], data['text']))
+        return types.SimpleNamespace()
+    dummy_requests.post = post
+    monkeypatch.setitem(sys.modules, 'requests', dummy_requests)
+
+    dummy_backtest = types.ModuleType('crypto_screener_ai.app.backtest')
+    dummy_backtest.run_backtest = lambda symbol: {'return_pct': 5.0}
+    monkeypatch.setitem(sys.modules, 'crypto_screener_ai.app.backtest', dummy_backtest)
+
+    sys.modules.pop('telegram_bot', None)
+    bot = importlib.import_module('telegram_bot')
+    bot.BASE_URL = 'http://test'
+    bot.PORTFOLIO_PATH = Path(tmp_path) / 'portfolio.json'
+    return bot, messages
+
+
+def test_buy_and_sell(tmp_path, monkeypatch):
+    bot, msgs = load_bot(tmp_path, monkeypatch)
+    bot.process_update({'message': {'chat': {'id': 1}, 'text': '/buy BTC 2'}})
+    data = json.loads(Path(bot.PORTFOLIO_PATH).read_text())
+    assert data['BTC'] == 2
+    bot.process_update({'message': {'chat': {'id': 1}, 'text': '/sell BTC 1'}})
+    data = json.loads(Path(bot.PORTFOLIO_PATH).read_text())
+    assert data['BTC'] == 1
+    assert msgs[-1][1] == 'Order executed'
+
+
+def test_unauthorized_trade(tmp_path, monkeypatch):
+    bot, msgs = load_bot(tmp_path, monkeypatch, allowed='2')
+    bot.process_update({'message': {'chat': {'id': 1}, 'text': '/buy BTC 1'}})
+    assert not Path(bot.PORTFOLIO_PATH).exists()
+    assert msgs[-1][1] == 'Not authorized'
+
+
+def test_backtest(tmp_path, monkeypatch):
+    bot, msgs = load_bot(tmp_path, monkeypatch)
+    bot.process_update({'message': {'chat': {'id': 1}, 'text': '/backtest BTC'}})
+    assert msgs[-1][1].startswith('Return:')
+


### PR DESCRIPTION
## Summary
- load default watch-list from cache when API fails or offline
- enhance `telegram_bot.py` to support `/buy`, `/sell` and `/backtest`
- restrict trades to `TELEGRAM_ALLOWED_IDS` and maintain a JSON portfolio
- include unit tests for telegram bot command handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860362979e8832b902085e0d0941a69

## Summary by Sourcery

Enable trading commands and backtesting in the Telegram bot with access control and persistent portfolio management, and strengthen error handling in volume fetching.

New Features:
- Add /buy, /sell and /backtest commands to the Telegram bot
- Restrict trading commands to allowed Telegram user IDs
- Persist portfolio updates in a JSON file

Enhancements:
- Refactor bot polling logic into a separate process_update function
- Improve fetch_top_25_volume to handle JSON load errors and offline cache fallback

Tests:
- Add unit tests for command handling of buy, sell, backtest and authorization