### PR TITLE
Refactor caching and offline tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - Added CSV/JSON export endpoints for backtests and portfolio risk metrics.
 - Added pluggable strategy loader and HTML report generation for backtests.
 - Improved top volume fetcher with caching fallback for offline mode.
+- Refactored DataFetcher caching to unify implementation and ensure data
+  directory creation.
 
 ## [0.1.0] - 2024-03-01
 - Initial release with CLI screener and dashboard.

--- a/PROPOSAL_ADDED_FEATURES_2024.md
+++ b/PROPOSAL_ADDED_FEATURES_2024.md
@@ -1,0 +1,10 @@
+# Complementary Feature Proposal
+
+To extend the existing alerts bot, the following ideas could add more value for users:
+
+1. **Real-Time Portfolio Tracker** – aggregate balances across multiple exchanges and display them in the dashboard.
+2. **Webhook Automation Rules** – allow users to trigger scripts or HTTP callbacks when specific indicators cross user-defined thresholds.
+3. **Enhanced Offline Mode** – optionally download daily snapshots of OHLCV data so the bot can operate with minimal connectivity.
+4. **Strategy Sharing Hub** – a simple section in the UI where traders can upload, browse and rate community strategies.
+
+These features would complement the current tooling by improving automation, collaboration and resiliency.

--- a/tests/test_data_offline.py
+++ b/tests/test_data_offline.py
@@ -1,46 +1,10 @@
-import sys, json
-from pathlib import Path
-import types, importlib
-import pytest
-
-pytest.importorskip("pandas")
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
-
-def test_data_fetcher_offline(monkeypatch):
-    class DummyExchange:
-        def fetch_ticker(self, *a, **k):
-            raise AssertionError('network should not be called')
-
-        def fetch_ohlcv(self, *a, **k):
-            raise AssertionError('network should not be called')
-
-    dummy_ccxt = types.ModuleType('ccxt')
-    dummy_ccxt.binance = lambda *a, **k: DummyExchange()
-    monkeypatch.setitem(sys.modules, 'ccxt', dummy_ccxt)
-
-    price_cache = Path('data/price_btcusdt.json')
-    ohlcv_cache = Path('data/ohlcv_btcusdt_1h.json')
-    price_cache.write_text(json.dumps(123.45))
-    ohlcv_cache.write_text(json.dumps([[0, 1, 2, 3, 4, 5]]))
-
-    monkeypatch.setenv('OFFLINE_MODE', '1')
-
-    data_mod = importlib.import_module('trading_bot.data')
-    fetcher = data_mod.DataFetcher('BTC/USDT')
-
-    price = fetcher.get_current_price()
-    df = fetcher.get_ohlcv('1h', limit=1)
-
-    assert price == 123.45
-    assert len(df) == 1
 import sys
 import json
-import types
 from pathlib import Path
+import types
 import pytest
-pd = pytest.importorskip('pandas')
+
+pd = pytest.importorskip("pandas")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -48,10 +12,9 @@ from trading_bot.data import DataFetcher
 
 
 def test_data_fetcher_offline(monkeypatch):
-    # prepare cache files
     price_cache = Path('data/price_btcusdt.json')
-    price_cache.write_text(json.dumps(123.45))
     ohlcv_cache = Path('data/ohlcv_btcusdt_1h.csv')
+
     df = pd.DataFrame({
         'timestamp': pd.date_range('2024-01-01', periods=3, freq='H'),
         'open': [1, 2, 3],
@@ -60,6 +23,8 @@ def test_data_fetcher_offline(monkeypatch):
         'close': [1.5, 2.5, 3.5],
         'volume': [10, 20, 30]
     })
+
+    price_cache.write_text(json.dumps(123.45))
     df.to_csv(ohlcv_cache, index=False)
 
     monkeypatch.setenv('OFFLINE_MODE', '1')
@@ -71,7 +36,7 @@ def test_data_fetcher_offline(monkeypatch):
     )
 
     price = fetcher.get_current_price()
-    data = fetcher.get_ohlcv()
+    data = fetcher.get_ohlcv(limit=3)
 
     assert price == 123.45
     assert len(data) == 3

--- a/trading_bot/data.py
+++ b/trading_bot/data.py
@@ -1,11 +1,9 @@
-import os
 import json
+import os
 from pathlib import Path
+
 import ccxt
 import pandas as pd
-import json
-import os
-from pathlib import Path
 
 
 class DataFetcher:
@@ -15,7 +13,7 @@ class DataFetcher:
         self.symbol = symbol
         self.exchange = ccxt.binance({"enableRateLimit": True})
         self.cache_dir = Path(__file__).resolve().parents[1] / "data"
-        self.cache_dir.mkdir(exist_ok=True)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def _price_cache(self) -> Path:
         sym = self.symbol.replace("/", "").lower()
@@ -26,15 +24,9 @@ class DataFetcher:
         return self.cache_dir / f"ohlcv_{sym}_{timeframe}.csv"
 
     def get_current_price(self) -> float:
-        """Return last trade price with optional offline fallback."""
-        cache_path = (
-            Path(__file__).resolve().parents[1]
-            / "data"
-            / f"price_{self.symbol.replace('/', '').lower()}.json"
-        )
-
         """Return last trade price, using cache if OFFLINE_MODE is set."""
         cache_path = self._price_cache()
+
         if os.getenv("OFFLINE_MODE") and cache_path.exists():
             return json.loads(cache_path.read_text())
 
@@ -49,42 +41,9 @@ class DataFetcher:
             raise
 
     def get_ohlcv(self, timeframe: str = "1h", limit: int = 500) -> pd.DataFrame:
-        """Return OHLCV data with optional offline fallback."""
-        cache_path = (
-            Path(__file__).resolve().parents[1]
-            / "data"
-            / f"ohlcv_{self.symbol.replace('/', '').lower()}_{timeframe}.json"
-        )
-
-        if os.getenv("OFFLINE_MODE") and cache_path.exists():
-            cached = json.loads(cache_path.read_text())
-            df = pd.DataFrame(
-                cached, columns=["timestamp", "open", "high", "low", "close", "volume"]
-            )
-            df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
-            return df
-
-        try:
-            data = self.exchange.fetch_ohlcv(
-                self.symbol, timeframe=timeframe, limit=limit
-            )
-            df = pd.DataFrame(
-                data, columns=["timestamp", "open", "high", "low", "close", "volume"]
-            )
-            df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
-            cache_path.write_text(json.dumps(data))
-            return df
-        except Exception:
-            if cache_path.exists():
-                cached = json.loads(cache_path.read_text())
-                df = pd.DataFrame(
-                    cached,
-                    columns=["timestamp", "open", "high", "low", "close", "volume"],
-                )
-                df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
-                return df
         """Return OHLCV data as a DataFrame, using cache if OFFLINE_MODE is set."""
         cache_path = self._ohlcv_cache(timeframe)
+
         if os.getenv("OFFLINE_MODE") and cache_path.exists():
             df = pd.read_csv(cache_path)
             df["timestamp"] = pd.to_datetime(df["timestamp"])


### PR DESCRIPTION
## Summary
- refactor `trading_bot.data` caching to use helper methods
- ensure data dir creation
- update offline data tests for unified caching
- document new complementary feature ideas
- note caching refactor in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860362a0d6c832ba9f1b80268d2f64a

## Summary by Sourcery

Refactor DataFetcher to centralize cache path logic, enforce data directory creation, update offline data tests for CSV-based caching, and add documentation for complementary feature proposals.

Enhancements:
- Unify price and OHLCV caching via dedicated helper methods in DataFetcher
- Ensure the data directory is created with parent directories
- Switch OHLCV cache to CSV format and simplify offline data loading

Documentation:
- Add PROPOSAL_ADDED_FEATURES_2024.md with feature ideas
- Note caching refactor in CHANGELOG

Tests:
- Update offline data tests to match CSV-based caching and new helper methods