### PR TITLE
Add API metrics helper and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Refactored DataFetcher caching to unify implementation and ensure data
   directory creation.
 - Added API monitoring with `/metrics` endpoint and helper to track upstream usage.
+  Metrics now include failure counts and total duration per service.
 
 ## [0.1.0] - 2024-03-01
 - Initial release with CLI screener and dashboard.

--- a/PROPOSAL_MORE_FEATURES.md
+++ b/PROPOSAL_MORE_FEATURES.md
@@ -1,0 +1,8 @@
+# Additional Complementary Features
+
+To further expand CryptoScreenerAI's capabilities, consider implementing:
+
+1. **Multi-Language Dashboard** – provide translations for the web interface so international users can navigate more easily.
+2. **Risk Scoring AI** – use machine learning to assign risk levels to coins based on volatility, liquidity and sentiment metrics.
+3. **Data Quality Monitor** – alert when upstream APIs return stale or inconsistent data to ensure backtests remain reliable.
+4. **Mobile Push Notifications** – integrate with Apple/Google push services to deliver alerts directly to users' phones.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ results are stored:
 - `DISCORD_WEBHOOK_URL` to send alerts to Discord
 
 The dashboard tracks usage of external APIs. Visit `/metrics` to view request
-counts, failures and total duration per provider.
+counts, failures and total duration per provider. Metrics accumulate while the
+application runs so you can monitor reliability trends.
 
 ## New Features
 - **Real-Time WebSockets**: Subscribe to `/ws/results` for instant screener updates.

--- a/crypto_screener_ai/web/dashboard.py
+++ b/crypto_screener_ai/web/dashboard.py
@@ -59,11 +59,13 @@ def send_push(message: str):
     if not token or not user:
         return
     try:
-        requests.post('https://api.pushover.net/1/messages.json', data={
-            'token': token,
-            'user': user,
-            'message': message,
-        }, timeout=10)
+        record_api_call(
+            'pushover',
+            requests.post,
+            'https://api.pushover.net/1/messages.json',
+            data={'token': token, 'user': user, 'message': message},
+            timeout=10,
+        )
     except Exception as exc:
         logger.warning('Push notification failed: %s', exc)
 
@@ -96,7 +98,7 @@ def send_slack(message: str):
     if not url:
         return
     try:
-        requests.post(url, json={'text': message}, timeout=10)
+        record_api_call('slack', requests.post, url, json={'text': message}, timeout=10)
     except Exception as exc:
         logger.warning('Slack alert failed: %s', exc)
 
@@ -107,7 +109,7 @@ def send_discord(message: str):
     if not url:
         return
     try:
-        requests.post(url, json={'content': message}, timeout=10)
+        record_api_call('discord', requests.post, url, json={'content': message}, timeout=10)
     except Exception as exc:
         logger.warning('Discord alert failed: %s', exc)
 
@@ -131,7 +133,14 @@ def send_custom_webhooks(payload: str):
     """POST JSON payload to all registered webhook URLs."""
     for url in load_webhook_urls():
         try:
-            requests.post(url, data=payload, headers={'Content-Type': 'application/json'}, timeout=10)
+            record_api_call(
+                'webhook',
+                requests.post,
+                url,
+                data=payload,
+                headers={'Content-Type': 'application/json'},
+                timeout=10,
+            )
         except Exception as exc:
             logger.warning('Custom webhook %s failed: %s', url, exc)
 

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -3,6 +3,7 @@ import time
 import json
 from pathlib import Path
 import requests
+from crypto_screener_ai.app.monitoring import record_api_call
 from typing import Dict
 
 from crypto_screener_ai.app.backtest import run_backtest
@@ -17,7 +18,13 @@ def send_message(chat_id: int, text: str):
     if not BASE_URL:
         return
     try:
-        requests.post(f"{BASE_URL}/sendMessage", data={'chat_id': chat_id, 'text': text}, timeout=10)
+        record_api_call(
+            "telegram",
+            requests.post,
+            f"{BASE_URL}/sendMessage",
+            data={'chat_id': chat_id, 'text': text},
+            timeout=10,
+        )
     except Exception:
         pass
 
@@ -25,7 +32,7 @@ def send_message(chat_id: int, text: str):
 def fetch_strategy_summary(name: str) -> str:
     url = f"http://localhost:9999/strategies/{name}"
     try:
-        res = requests.get(url, timeout=10)
+        res = record_api_call("dashboard", requests.get, url, timeout=10)
         if res.status_code != 200:
             return "Strategy not found"
         js = res.json()
@@ -62,7 +69,13 @@ def run_bot(poll_interval: int = 5):
     offset = 0
     while True:
         try:
-            resp = requests.get(f"{BASE_URL}/getUpdates", params={'timeout': 30, 'offset': offset+1}, timeout=35)
+            resp = record_api_call(
+                "telegram",
+                requests.get,
+                f"{BASE_URL}/getUpdates",
+                params={'timeout': 30, 'offset': offset + 1},
+                timeout=35,
+            )
             resp.raise_for_status()
             data = resp.json().get('result', [])
             for update in data:

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -48,3 +48,29 @@ def test_api_metrics(monkeypatch, tmp_path):
     assert monitoring.API_METRICS['binance']['failures'] == 0
     assert monitoring.API_METRICS['binance']['duration'] > 0
 
+
+def test_social_posts_metrics(monkeypatch, tmp_path):
+    from tests.test_dashboard import load_dashboard
+    monitoring = importlib.import_module('crypto_screener_ai.app.monitoring')
+    monitoring.API_METRICS.clear()
+    mod = load_dashboard(tmp_path)
+    mod.fetch_social_posts()
+    assert monitoring.API_METRICS['reddit']['count'] == 1
+    assert monitoring.API_METRICS['reddit']['failures'] == 0
+    assert monitoring.API_METRICS['reddit']['duration'] > 0
+
+
+def test_top25_metrics(monkeypatch):
+    monitoring = importlib.import_module('crypto_screener_ai.app.monitoring')
+    monitoring.API_METRICS.clear()
+    dummy_requests = types.ModuleType('requests')
+    dummy_requests.get = lambda *a, **k: types.SimpleNamespace(json=lambda:[{'symbol':'btc'},{'symbol':'eth'}], raise_for_status=lambda: None)
+    monkeypatch.setitem(sys.modules, 'requests', dummy_requests)
+    sys.modules.pop('crypto_screener_ai.app.run_screener', None)
+    run_screener = importlib.import_module('crypto_screener_ai.app.run_screener')
+    top = run_screener.fetch_top_25_volume()
+    assert top == ['BTC', 'ETH']
+    assert monitoring.API_METRICS['coingecko']['count'] == 1
+    assert monitoring.API_METRICS['coingecko']['failures'] == 0
+    assert monitoring.API_METRICS['coingecko']['duration'] > 0
+

--- a/trading_bot/data.py
+++ b/trading_bot/data.py
@@ -93,7 +93,13 @@ class DataFetcher:
             return df.head(limit)
 
         try:
-            data = self.exchange.fetch_ohlcv(self.symbol, timeframe=timeframe, limit=limit)
+            data = record_api_call(
+                "binance",
+                self.exchange.fetch_ohlcv,
+                self.symbol,
+                timeframe=timeframe,
+                limit=limit,
+            )
             df = pd.DataFrame(
                 data,
                 columns=["timestamp", "open", "high", "low", "close", "volume"],


### PR DESCRIPTION
## Summary
- track upstream usage metrics with `API_METRICS`
- wrap Telegram bot and webhook calls with `record_api_call`
- monitor Binance OHLCV fetches in `DataFetcher`
- extend monitoring unit tests
- mention metrics behaviour in README and CHANGELOG
- document more complementary feature ideas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603e207b88832ba6eda2d1bf78f406

## Summary by Sourcery

Add a generic API metrics helper and instrument existing external calls to record usage metrics, extend monitoring tests, and update user-facing documentation.

New Features:
- Introduce a `record_api_call` helper to collect counts, failures, and durations for upstream services
- Instrument Pushover, Slack, Discord, custom webhooks, Telegram bot, dashboard data fetch, and Binance OHLCV calls to record API metrics

Documentation:
- Clarify metrics accumulation behavior in README and CHANGELOG
- Add a proposal document outlining additional complementary feature ideas

Tests:
- Add unit tests for Reddit social posts and CoinGecko top-25 volume fetch metrics