### PR TITLE
Extend Telegram bot trade commands and docs

### DIFF
--- a/PROPOSAL_ADDITIONAL_COMPLEMENT.md
+++ b/PROPOSAL_ADDITIONAL_COMPLEMENT.md
@@ -1,0 +1,9 @@
+# Additional Complementary Features
+
+To further enhance the trading bot and its integrations, consider these ideas:
+
+1. **Real-time PnL Tracking** – display profit and loss for each symbol in the Telegram bot using the portfolio file as a data source.
+2. **Inline Keyboard Actions** – provide quick buy/sell buttons in Telegram messages for commonly traded symbols.
+3. **Multi-Language Responses** – detect user language preferences and localize bot messages.
+4. **CSV Portfolio Import/Export** – allow users to back up or restore the portfolio via a simple CSV file.
+5. **Custom Alert Rules** – let users create personalized conditions that trigger Telegram notifications or webhooks.

--- a/PROPOSAL_FURTHER_ENHANCEMENTS.md
+++ b/PROPOSAL_FURTHER_ENHANCEMENTS.md
@@ -1,0 +1,9 @@
+# Future Enhancements
+
+The following ideas could further complement the alerts bot and trading system:
+
+1. **Real-time Price Charts** – generate small sparkline images on demand so Telegram users can view recent price action without leaving the chat.
+2. **Automated Portfolio Rebalancing** – allow users to set target allocations and automatically compute trades to maintain them.
+3. **Voice Command Support** – integrate basic speech-to-text so users can issue trade or inquiry commands hands-free from mobile devices.
+4. **Two-Factor Authorization** – require a secondary code or confirmation step for high-value trades or withdrawals.
+5. **DeFi Integration** – extend order routing to decentralized exchanges for tokens not listed on major CEXs.

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -5,19 +5,58 @@ from pathlib import Path
 import requests
 from typing import Dict
 
+from trading_bot.data import DataFetcher
+
 from crypto_screener_ai.app.backtest import run_backtest
 
 API_TOKEN = os.getenv('TELEGRAM_TOKEN')
 BASE_URL = f"https://api.telegram.org/bot{API_TOKEN}" if API_TOKEN else None
 ALLOWED_IDS = [int(x) for x in os.getenv("TELEGRAM_ALLOWED_IDS", "").split(",") if x.strip()]
 PORTFOLIO_PATH = Path("data/telegram_portfolio.json")
+PORTFOLIO_CSV_PATH = Path("data/telegram_portfolio.csv")
+ALERT_RULES_PATH = Path("data/alert_rules.json")
+
+MESSAGES = {
+    'en': {
+        'not_auth': 'Not authorized',
+        'usage': 'Usage: /buy SYMBOL QTY',
+        'invalid_qty': 'Invalid quantity',
+        'executed': 'Order executed',
+        'pnl_header': 'PnL Summary',
+        'alert_added': 'Alert added',
+        'alert_triggered': 'Alert triggered'
+    },
+    'es': {
+        'not_auth': 'No autorizado',
+        'usage': 'Uso: /buy SIMBOLO CANTIDAD',
+        'invalid_qty': 'Cantidad no válida',
+        'executed': 'Orden ejecutada',
+        'pnl_header': 'Resumen de PnL',
+        'alert_added': 'Alerta agregada',
+        'alert_triggered': 'Alerta activada'
+    }
+}
+
+def tr(key: str, lang: str) -> str:
+    lang = lang if lang in MESSAGES else 'en'
+    return MESSAGES[lang].get(key, key)
 
 
-def send_message(chat_id: int, text: str):
+def get_price(symbol: str) -> float:
+    """Fetch current price from Binance via DataFetcher."""
+    fetcher = DataFetcher(f"{symbol.upper()}/USDT")
+    return float(fetcher.get_current_price())
+
+
+def send_message(chat_id: int, text: str, reply_markup: dict | None = None):
+    """Send a message via Telegram with optional inline keyboard."""
     if not BASE_URL:
         return
+    payload = {'chat_id': chat_id, 'text': text}
+    if reply_markup:
+        payload['reply_markup'] = json.dumps(reply_markup)
     try:
-        requests.post(f"{BASE_URL}/sendMessage", data={'chat_id': chat_id, 'text': text}, timeout=10)
+        requests.post(f"{BASE_URL}/sendMessage", data=payload, timeout=10)
     except Exception:
         pass
 
@@ -34,26 +73,123 @@ def fetch_strategy_summary(name: str) -> str:
         return 'Error fetching strategy'
 
 
-def load_portfolio() -> Dict[str, float]:
+def load_portfolio() -> Dict[str, dict]:
+    """Return portfolio mapping symbol -> {qty, avg_price}."""
     if PORTFOLIO_PATH.exists():
         try:
-            return json.loads(PORTFOLIO_PATH.read_text())
+            data = json.loads(PORTFOLIO_PATH.read_text())
+            for sym, val in list(data.items()):
+                if isinstance(val, (int, float)):
+                    data[sym] = {"qty": float(val), "avg_price": 0.0}
+            return data
         except Exception:
             return {}
     return {}
 
 
-def save_portfolio(data: Dict[str, float]):
+def save_portfolio(data: Dict[str, dict]):
     PORTFOLIO_PATH.write_text(json.dumps(data))
 
 
-def update_portfolio(symbol: str, qty: float):
+def update_portfolio(symbol: str, qty: float, price: float):
+    """Update holding quantity and average price."""
     port = load_portfolio()
     sym = symbol.upper()
-    port[sym] = port.get(sym, 0) + qty
-    if abs(port[sym]) < 1e-8:
-        port.pop(sym)
+    entry = port.get(sym, {"qty": 0.0, "avg_price": 0.0})
+    if qty > 0:
+        total_cost = entry["avg_price"] * entry["qty"] + price * qty
+        entry["qty"] += qty
+        entry["avg_price"] = total_cost / entry["qty"]
+    else:
+        entry["qty"] += qty
+    if abs(entry["qty"]) < 1e-8:
+        port.pop(sym, None)
+    else:
+        port[sym] = entry
     save_portfolio(port)
+
+
+def export_portfolio_csv():
+    """Save portfolio to CSV file."""
+    port = load_portfolio()
+    with PORTFOLIO_CSV_PATH.open("w") as fh:
+        fh.write("symbol,qty,avg_price\n")
+        for sym, info in port.items():
+            fh.write(f"{sym},{info['qty']},{info.get('avg_price',0)}\n")
+
+
+def import_portfolio_csv():
+    """Load portfolio from CSV, replacing current file."""
+    if not PORTFOLIO_CSV_PATH.exists():
+        return False
+    port: Dict[str, dict] = {}
+    for line in PORTFOLIO_CSV_PATH.read_text().splitlines()[1:]:
+        sym, qty, price = line.split(',')
+        port[sym.upper()] = {"qty": float(qty), "avg_price": float(price)}
+    save_portfolio(port)
+    return True
+
+
+def load_alert_rules() -> list:
+    if ALERT_RULES_PATH.exists():
+        try:
+            return json.loads(ALERT_RULES_PATH.read_text())
+        except Exception:
+            return []
+    return []
+
+
+def save_alert_rules(rules: list):
+    ALERT_RULES_PATH.write_text(json.dumps(rules))
+
+
+def add_alert_rule(symbol: str, op: str, value: float, chat_id: int):
+    rules = load_alert_rules()
+    rules.append({"symbol": symbol.upper(), "op": op, "value": value, "chat_id": chat_id})
+    save_alert_rules(rules)
+
+
+def check_alert_rules():
+    rules = load_alert_rules()
+    if not rules:
+        return
+    for rule in list(rules):
+        try:
+            price = get_price(rule["symbol"])
+        except Exception:
+            continue
+        if rule["op"] == ">" and price > rule["value"]:
+            send_message(rule["chat_id"], f"{tr('alert_triggered','en')}: {rule['symbol']} {price} > {rule['value']}")
+            rules.remove(rule)
+        if rule["op"] == "<" and price < rule["value"]:
+            send_message(rule["chat_id"], f"{tr('alert_triggered','en')}: {rule['symbol']} {price} < {rule['value']}")
+            rules.remove(rule)
+    save_alert_rules(rules)
+
+
+def compute_pnl(lang: str) -> str:
+    port = load_portfolio()
+    if not port:
+        return tr('pnl_header', lang) + ': empty'
+    lines = [tr('pnl_header', lang) + ':']
+    for sym, info in port.items():
+        try:
+            price = get_price(sym)
+        except Exception:
+            continue
+        pnl = (price - info.get('avg_price', 0)) * info['qty']
+        lines.append(f"{sym}: qty={info['qty']:.4f} pnl={pnl:.2f}")
+    return '\n'.join(lines)
+
+
+def send_trade_buttons(chat_id: int, symbol: str):
+    kb = {
+        "inline_keyboard": [
+            [{"text": f"Buy {symbol}", "callback_data": f"BUY {symbol} 1"}],
+            [{"text": f"Sell {symbol}", "callback_data": f"SELL {symbol} 1"}],
+        ]
+    }
+    send_message(chat_id, f"Trade {symbol}", reply_markup=kb)
 
 
 def run_bot(poll_interval: int = 5):
@@ -68,6 +204,7 @@ def run_bot(poll_interval: int = 5):
             for update in data:
                 offset = update['update_id']
                 process_update(update)
+            check_alert_rules()
         except Exception:
             time.sleep(poll_interval)
             continue
@@ -75,9 +212,17 @@ def run_bot(poll_interval: int = 5):
 
 
 def process_update(update: Dict):
+    if 'callback_query' in update:
+        data = update['callback_query']['data']
+        chat_id = update['callback_query']['message']['chat']['id']
+        update = {'message': {'chat': {'id': chat_id}, 'text': '/' + data.lower()}}
+        process_update(update)
+        return
+
     msg = update.get('message', {})
     chat_id = msg.get('chat', {}).get('id')
     text = msg.get('text', '')
+    lang = msg.get('from', {}).get('language_code', 'en')[:2]
     if not chat_id or not text:
         return
 
@@ -99,20 +244,53 @@ def process_update(update: Dict):
 
     if text.startswith('/buy ') or text.startswith('/sell '):
         if chat_id not in ALLOWED_IDS:
-            send_message(chat_id, 'Not authorized')
+            send_message(chat_id, tr('not_auth', lang))
             return
         parts = text.split()
         if len(parts) != 3:
-            send_message(chat_id, 'Usage: /buy SYMBOL QTY')
+            send_message(chat_id, tr('usage', lang))
             return
         symbol = parts[1]
         try:
             qty = float(parts[2])
         except ValueError:
-            send_message(chat_id, 'Invalid quantity')
+            send_message(chat_id, tr('invalid_qty', lang))
             return
         if text.startswith('/sell'):
             qty = -qty
-        update_portfolio(symbol, qty)
-        send_message(chat_id, 'Order executed')
+        price = get_price(symbol)
+        update_portfolio(symbol, qty, price)
+        send_message(chat_id, tr('executed', lang))
+        return
+
+    if text.startswith('/pnl'):
+        send_message(chat_id, compute_pnl(lang))
+        return
+
+    if text.startswith('/trade '):
+        symbol = text.split()[1]
+        send_trade_buttons(chat_id, symbol.upper())
+        return
+
+    if text.startswith('/export_portfolio'):
+        export_portfolio_csv()
+        send_message(chat_id, 'CSV exported')
+        return
+
+    if text.startswith('/import_portfolio'):
+        if import_portfolio_csv():
+            send_message(chat_id, 'CSV imported')
+        else:
+            send_message(chat_id, 'CSV not found')
+        return
+
+    if text.startswith('/alert '):
+        try:
+            _, sym, op, val = text.split()
+            add_alert_rule(sym, op, float(val), chat_id)
+            send_message(chat_id, tr('alert_added', lang))
+        except Exception:
+            send_message(chat_id, 'Usage: /alert SYMBOL >|< PRICE')
+        return
+
 

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -15,7 +15,7 @@ def load_bot(tmp_path, monkeypatch, allowed='1'):
 
     dummy_requests = types.ModuleType('requests')
     def post(url, data=None, timeout=10):
-        messages.append((data['chat_id'], data['text']))
+        messages.append((data['chat_id'], data['text'], data.get('reply_markup')))
         return types.SimpleNamespace()
     dummy_requests.post = post
     monkeypatch.setitem(sys.modules, 'requests', dummy_requests)
@@ -24,10 +24,21 @@ def load_bot(tmp_path, monkeypatch, allowed='1'):
     dummy_backtest.run_backtest = lambda symbol: {'return_pct': 5.0}
     monkeypatch.setitem(sys.modules, 'crypto_screener_ai.app.backtest', dummy_backtest)
 
+    dummy_data = types.ModuleType('trading_bot.data')
+    class DummyFetcher:
+        def __init__(self, symbol='BTC/USDT'):
+            self.price = 100.0
+        def get_current_price(self):
+            return self.price
+    dummy_data.DataFetcher = DummyFetcher
+    monkeypatch.setitem(sys.modules, 'trading_bot.data', dummy_data)
+
     sys.modules.pop('telegram_bot', None)
     bot = importlib.import_module('telegram_bot')
     bot.BASE_URL = 'http://test'
     bot.PORTFOLIO_PATH = Path(tmp_path) / 'portfolio.json'
+    bot.PORTFOLIO_CSV_PATH = Path(tmp_path) / 'portfolio.csv'
+    bot.ALERT_RULES_PATH = Path(tmp_path) / 'alerts.json'
     return bot, messages
 
 
@@ -35,10 +46,10 @@ def test_buy_and_sell(tmp_path, monkeypatch):
     bot, msgs = load_bot(tmp_path, monkeypatch)
     bot.process_update({'message': {'chat': {'id': 1}, 'text': '/buy BTC 2'}})
     data = json.loads(Path(bot.PORTFOLIO_PATH).read_text())
-    assert data['BTC'] == 2
+    assert data['BTC']['qty'] == 2
     bot.process_update({'message': {'chat': {'id': 1}, 'text': '/sell BTC 1'}})
     data = json.loads(Path(bot.PORTFOLIO_PATH).read_text())
-    assert data['BTC'] == 1
+    assert data['BTC']['qty'] == 1
     assert msgs[-1][1] == 'Order executed'
 
 
@@ -46,11 +57,37 @@ def test_unauthorized_trade(tmp_path, monkeypatch):
     bot, msgs = load_bot(tmp_path, monkeypatch, allowed='2')
     bot.process_update({'message': {'chat': {'id': 1}, 'text': '/buy BTC 1'}})
     assert not Path(bot.PORTFOLIO_PATH).exists()
-    assert msgs[-1][1] == 'Not authorized'
+    assert msgs[-1][1] in ['Not authorized', 'No autorizado']
 
 
 def test_backtest(tmp_path, monkeypatch):
     bot, msgs = load_bot(tmp_path, monkeypatch)
     bot.process_update({'message': {'chat': {'id': 1}, 'text': '/backtest BTC'}})
     assert msgs[-1][1].startswith('Return:')
+
+
+def test_pnl_and_csv(tmp_path, monkeypatch):
+    bot, msgs = load_bot(tmp_path, monkeypatch)
+    prices = {'BTC': 100.0}
+    monkeypatch.setattr(bot, 'get_price', lambda s: prices[s])
+    bot.process_update({'message': {'chat': {'id': 1}, 'text': '/buy BTC 1', 'from': {'language_code': 'en'}}})
+    prices['BTC'] = 110.0
+    bot.process_update({'message': {'chat': {'id': 1}, 'text': '/pnl', 'from': {'language_code': 'en'}}})
+    assert 'pnl=' in msgs[-1][1]
+    bot.process_update({'message': {'chat': {'id': 1}, 'text': '/export_portfolio'}})
+    assert Path(bot.PORTFOLIO_CSV_PATH).exists()
+    Path(bot.PORTFOLIO_CSV_PATH).write_text('symbol,qty,avg_price\nETH,2,200')
+    bot.process_update({'message': {'chat': {'id': 1}, 'text': '/import_portfolio'}})
+    data = json.loads(Path(bot.PORTFOLIO_PATH).read_text())
+    assert 'ETH' in data
+
+
+def test_alert_rule_and_language(tmp_path, monkeypatch):
+    bot, msgs = load_bot(tmp_path, monkeypatch)
+    price = {'BTC': 90.0}
+    monkeypatch.setattr(bot, 'get_price', lambda s: price[s])
+    bot.process_update({'message': {'chat': {'id': 1}, 'text': '/alert BTC > 100', 'from': {'language_code': 'es'}}})
+    price['BTC'] = 110.0
+    bot.check_alert_rules()
+    assert any('Alerta' in m[1] or 'Alert' in m[1] for m in msgs)
 


### PR DESCRIPTION
## Summary
- parse `/buy`, `/sell`, and `/backtest` in `telegram_bot.py`
- keep trade commands restricted to `TELEGRAM_ALLOWED_IDS`
- simulate trades in `data/telegram_portfolio.json`
- return backtest summary to the user
- provide test coverage for these commands
- document further complementary feature ideas
- implement PnL tracking, inline buttons, multi-language, CSV import/export and alert rules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68603e275130832ba92b98d2f8c93f6c

## Summary by Sourcery

Extend the Telegram bot to fully support buy, sell and backtest commands with portfolio persistence, real-time PnL tracking, inline trade buttons, CSV import/export, multilingual responses, and customizable price alerts, along with comprehensive test coverage and feature proposal documentation.

New Features:
- Add /pnl command to display current portfolio profit and loss
- Add /trade command with inline buy/sell buttons
- Add /export_portfolio and /import_portfolio commands for CSV backup and restore
- Add /alert command for custom price alert rules
- Extend /backtest command to return summary results in chat

Enhancements:
- Persist portfolio with quantity and average price in JSON and CSV formats
- Integrate live price fetching via DataFetcher for trades and PnL
- Restrict trade commands to configured TELEGRAM_ALLOWED_IDS
- Handle Telegram callback queries for inline keyboards
- Provide multilingual (English/Spanish) bot responses

Documentation:
- Add Markdown proposals for complementary features and future enhancements

Tests:
- Add tests for buy/sell, backtest, PnL computation, CSV import/export, and alert rule triggering